### PR TITLE
refactor: unify badge and card helpers

### DIFF
--- a/components/AboutSection.jsx
+++ b/components/AboutSection.jsx
@@ -1,0 +1,242 @@
+import { useState, useEffect, useMemo } from 'react';
+import Badge from '@/components/ui/Badge';
+import ActivityToggle from '@/components/ui/ActivityToggle';
+import BarSparkline from '@/components/ui/BarSparkline';
+import SpotifyTopArtists from '@/components/SpotifyTopArtists';
+import SpotifyTopTracks from '@/components/SpotifyTopTracks';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/Card';
+import Stat from '@/components/ui/Stat';
+import { Sparkles, Brain, Target } from 'lucide-react';
+
+function useStats() {
+  const [stats, setStats] = useState(null);
+  useEffect(() => {
+    fetch('/stats.json', { cache: 'no-cache' })
+      .then(r => (r.ok ? r.json() : null))
+      .then(setStats)
+      .catch(() => setStats(null));
+  }, []);
+  return stats;
+}
+
+function useSpotify() {
+  const [data, setData] = useState(null);
+  useEffect(() => {
+    fetch('/spotify.json', { cache: 'no-cache' })
+      .then(r => (r.ok ? r.json() : null))
+      .then(setData)
+      .catch(() => setData(null));
+  }, []);
+  return data;
+}
+
+export default function AboutSection({ interests }) {
+  const stats = useStats();
+  const spotify = useSpotify();
+  const [activity, setActivity] = useState('combined');
+
+  const data = stats?.stats?.[activity];
+  const monthly = data?.monthly;
+  const series = data?.weekly?.series ?? [];
+
+  const weeklyValues = useMemo(
+    () => series.map(w => w.distance_km),
+    [series]
+  );
+
+  const lastWeek = weeklyValues.length > 1 ? weeklyValues.at(-2) : undefined;
+  const bestWeek = weeklyValues.length ? Math.max(...weeklyValues) : undefined;
+  const generatedAt = stats ? new Date(stats.generated_at) : null;
+  const updatedAt = generatedAt
+    ? new Date(
+        generatedAt.getTime() -
+          (10 - (generatedAt.getDate() % 11)) * 60 * 1000
+      )
+    : null;
+
+  return (
+    <section id="about" className="relative scroll-mt-16">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 -z-10 opacity-30 dark:opacity-20"
+        style={{
+          background:
+            'radial-gradient(60% 40% at 50% 20%, rgba(15,23,42,0.08), transparent 60%)'
+        }}
+      />
+      <div className="section-container py-14 space-y-10">
+        <div className="grid md:grid-cols-5 gap-8 items-start">
+          <div className="md:col-span-3 space-y-5">
+            <Badge icon={Sparkles} variant="outline">
+              About me
+            </Badge>
+            <h2 className="text-3xl md:text-4xl font-extrabold tracking-tight">
+              I learn by building — from algorithms to UX.
+            </h2>
+            <p className="text-lg text-slate-600 dark:text-slate-300">
+              My sweet spot is where CS fundamentals meet practical impact. I’ve built
+              projects across computer vision, game-theoretic search, and systems-level C,
+              and I enjoy shaping ideas into reliable, maintainable software.
+            </p>
+          </div>
+
+          <div className="md:col-span-2">
+            <Card>
+              <CardHeader>
+                <CardTitle icon={Brain}>Interests</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="flex flex-wrap gap-2">
+                  {interests.map(i => <Badge key={i}>{i}</Badge>)}
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+
+        <div className="grid md:grid-cols-3 gap-6">
+          <Card className="md:col-span-2">
+            <CardHeader>
+              <CardTitle icon={Target}>Part-Time Work</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ul className="list-disc pl-5 space-y-2">
+                <li><strong>Semi-Professional Poker (NLHE)</strong> — probabilistic reasoning, risk management, and disciplined decision-making.</li>
+                <li><strong>Computer Science Tutor (CSA)</strong> — mentoring on fundamentals, debugging strategies, and problem-solving patterns.</li>
+              </ul>
+            </CardContent>
+          </Card>
+        </div>
+
+        <div className="grid md:grid-cols-3 gap-6">
+          <Card className="md:col-span-2">
+            <CardHeader action={<ActivityToggle activity={activity} onChange={setActivity} />}>
+              <CardTitle>
+                Monthly Training (last {monthly?.window_days ?? 30} days)
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="grid sm:grid-cols-3 gap-4">
+              <Stat
+                value={monthly ? monthly.distance_km : '—'}
+                label="Total distance (km)"
+              />
+              <Stat
+                value={monthly?.time_hours ?? '—'}
+                label="Total hours"
+              />
+              <Stat
+                value={monthly?.activities_count ?? '—'}
+                label="Activities"
+              />
+              {monthly && updatedAt && (
+                <div className="sm:col-span-3 text-sm opacity-70 text-center">
+                  Longest: {monthly.longest_km} km · Updated{' '}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Recent</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ul className="space-y-3">
+                {(data?.recent?.last3 ?? []).map(a => (
+                  <li key={a.id} className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="font-medium truncate">
+                        {a.name || a.type || 'Activity'}
+                      </div>
+                      <div className="text-xs opacity-70">{a.start}</div>
+                    </div>
+                    <div className="text-right shrink-0">
+                      <div className="text-sm">{a.distance_km} km</div>
+                      <div className="text-xs opacity-70">{a.duration_min} min</div>
+                    </div>
+                  </li>
+                ))}
+                {!data?.recent?.last3?.length && (
+                  <div className="text-sm opacity-70">No recent activities</div>
+                )}
+              </ul>
+            </CardContent>
+          </Card>
+        </div>
+
+        <Card>
+          <CardHeader action={<ActivityToggle activity={activity} onChange={setActivity} />}>
+            <CardTitle className="flex items-center gap-2">
+              Weekly Training
+              {weeklyValues.length > 1 && (
+                <span className="text-sm opacity-70">
+                  • last: <strong>{typeof lastWeek === 'number' ? lastWeek.toFixed(1) : '—'}</strong> km
+                </span>
+              )}
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            {series.length ? (
+              <div className="grid md:grid-cols-2 gap-6 text-slate-900 dark:text-slate-100">
+                <div>
+                  <div className="flex items-center justify-between mb-2">
+                    <div className="text-sm font-medium opacity-80">Hours</div>
+                  </div>
+                  <BarSparkline
+                    values={series.map(w => w.time_hours)}
+                    formatter={(v, i) => {
+                      const w = series[i];
+                      const label = w ? `${w.week_start} → ${w.week_end}` : `Week ${i + 1}`;
+                      return `${label}: ${v.toFixed(2)} h`;
+                    }}
+                  />
+                </div>
+                <div>
+                  <div className="flex items-center justify-between mb-2">
+                    <div className="text-sm font-medium opacity-80">Distance (km)</div>
+                  </div>
+                  <BarSparkline
+                    values={series.map(w => w.distance_km)}
+                    formatter={(v, i) => {
+                      const w = series[i];
+                      const label = w ? `${w.week_start} → ${w.week_end}` : `Week ${i + 1}`;
+                      return `${label}: ${v.toFixed(1)} km`;
+                    }}
+                  />
+                </div>
+              </div>
+            ) : (
+              <div className="text-sm opacity-70">No weekly data yet</div>
+            )}
+            {weeklyValues.length ? (
+              <div className="mt-3 text-xs opacity-70">
+                Best distance week: {typeof bestWeek === 'number' ? bestWeek.toFixed(1) : '—'} km ·
+                Updated {stats ? new Date(stats.generated_at).toLocaleDateString() : '—'}
+              </div>
+            ) : null}
+          </CardContent>
+        </Card>
+
+        <div className="grid md:grid-cols-3 gap-6">
+          <Card className="md:col-span-2">
+            <CardHeader>
+              <CardTitle>Top Artists</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <SpotifyTopArtists artists={spotify?.artists ?? []} />
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader>
+              <CardTitle>Top Tracks</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <SpotifyTopTracks tracks={spotify?.tracks ?? []} />
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </section>
+  );
+}
+

--- a/components/EducationItem.jsx
+++ b/components/EducationItem.jsx
@@ -1,0 +1,19 @@
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/Card';
+
+export default function EducationItem({ item }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{item.school}</CardTitle>
+        <div className="text-sm opacity-70">{item.degree}</div>
+      </CardHeader>
+      <CardContent>
+        <ul className="list-disc pl-5 space-y-2">
+          {item.extras.map((x, i) => (
+            <li key={i}>{x}</li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/Footer.jsx
+++ b/components/Footer.jsx
@@ -1,0 +1,29 @@
+import { Github, Linkedin, Mail, FileText } from 'lucide-react';
+import PillLink from '@/components/ui/PillLink';
+
+export default function Footer({ links }) {
+  return (
+    <footer className="border-t dark:border-slate-800 py-10 mt-10">
+      <div className="section-container flex items-center justify-between">
+        <p className="text-sm opacity-70">
+          © {new Date().getFullYear()} Sean P. May. All rights reserved.
+        </p>
+        <div className="flex gap-3">
+          <PillLink href={links.github} icon={Github} external>
+            GitHub
+          </PillLink>
+          <PillLink href={links.linkedin} icon={Linkedin} external>
+            LinkedIn
+          </PillLink>
+          <PillLink href={links.email} icon={Mail}>
+            Email
+          </PillLink>
+          <PillLink href={links.resume} icon={FileText} external variant="solid">
+            Resume
+          </PillLink>
+        </div>
+      </div>
+    </footer>
+  );
+}
+

--- a/components/Header.jsx
+++ b/components/Header.jsx
@@ -1,0 +1,30 @@
+import ThemeToggle from '@/components/ThemeToggle';
+import PillLink from '@/components/ui/PillLink';
+import { FileText } from 'lucide-react';
+
+export default function Header({ links }) {
+  return (
+    <header className="sticky top-0 z-20 backdrop-blur border-b bg-white/70 dark:bg-slate-900/70 dark:border-slate-800">
+      <div className="section-container flex items-center justify-between h-16">
+        <a href="#home" className="font-bold tracking-tight text-xl">Sean P. May</a>
+        <nav className="hidden sm:flex items-center gap-2">
+          {['about', 'projects', 'experience', 'education', 'skills'].map(id => (
+            <PillLink
+              key={id}
+              href={`#${id}`}
+              variant="solid"
+              className="capitalize hover:bg-slate-100 dark:hover:bg-slate-800"
+            >
+              {id}
+            </PillLink>
+          ))}
+          <PillLink href={links.resume} icon={FileText} external>
+            Resume
+          </PillLink>
+          <ThemeToggle />
+        </nav>
+      </div>
+    </header>
+  );
+}
+

--- a/components/Hero.jsx
+++ b/components/Hero.jsx
@@ -1,0 +1,65 @@
+import { MapPin, Brain, FileText } from 'lucide-react';
+import Badge from '@/components/ui/Badge';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/Card';
+import PillLink from '@/components/ui/PillLink';
+
+export default function Hero({ links }) {
+  return (
+    <section id="home" className="section-container py-16 scroll-mt-16">
+      <div className="grid md:grid-cols-5 gap-8 items-center">
+        <div className="md:col-span-3 space-y-5">
+          <Badge icon={MapPin} variant="outline">
+            Boston, MA
+          </Badge>
+          <h1 className="text-4xl md:text-5xl font-extrabold tracking-tight">
+            CS/Math engineer building ML + systems projects
+          </h1>
+          <p className="text-lg text-slate-600 dark:text-slate-300 max-w-2xl">
+            I design and ship clean, usable software — from low-level C to applied ML.
+          </p>
+          <ul className="text-sm text-slate-600 dark:text-slate-300 space-y-1">
+            <li>🎓 Northeastern University — B.S. CS & Math (May 2027)</li>
+            <li>🧪 Incoming: NExT Program SWE Co-op (Fall 2025)</li>
+            <li>🔎 Open to Summer/Fall 2026 SWE/ML roles</li>
+          </ul>
+          <div className="flex flex-wrap gap-3 pt-2">
+            <PillLink href="#projects" variant="solid" className="px-4">
+              See projects
+            </PillLink>
+            <PillLink href={links.github} external className="px-4">
+              GitHub
+            </PillLink>
+            <PillLink href={links.linkedin} external className="px-4">
+              LinkedIn
+            </PillLink>
+            <PillLink href={links.email} variant="solid" className="px-4">
+              Contact
+            </PillLink>
+          </div>
+        </div>
+
+        <div className="md:col-span-2">
+          <Card>
+            <CardHeader>
+              <CardTitle icon={Brain}>Snapshot</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              <div className="flex flex-wrap gap-2">
+                <Badge>ML</Badge>
+                <Badge>Systems</Badge>
+                <Badge>Full-stack</Badge>
+              </div>
+              <p className="text-sm text-slate-600 dark:text-slate-300">
+                Focused on game theory, computer vision, and performance-minded code.
+              </p>
+              <PillLink href={links.resume} icon={FileText} external>
+                Resume
+              </PillLink>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </section>
+  );
+}
+

--- a/components/ListSection.jsx
+++ b/components/ListSection.jsx
@@ -1,0 +1,12 @@
+import Section from '@/components/ui/Section';
+
+export default function ListSection({ id, title, icon, items, renderItem, columns = 1 }) {
+  const gridCols = columns === 2 ? 'md:grid-cols-2' : columns === 3 ? 'md:grid-cols-3' : '';
+  return (
+    <Section id={id} title={title} icon={icon}>
+      <div className={`grid gap-6 ${gridCols}`.trim()}>
+        {items.map((item, i) => renderItem(item, i))}
+      </div>
+    </Section>
+  );
+}

--- a/components/ProjectCard.jsx
+++ b/components/ProjectCard.jsx
@@ -1,5 +1,6 @@
-import Badge from "./ui/Badge";
-import { Card, CardHeader, CardTitle, CardContent } from "./ui/Card";
+import Badge from './ui/Badge';
+import { Card, CardHeader, CardTitle, CardContent } from './ui/Card';
+import PillLink from './ui/PillLink';
 
 export default function ProjectCard({ project }) {
   const { title, period, stack = [], bullets = [], links = [] } = project;
@@ -25,9 +26,9 @@ export default function ProjectCard({ project }) {
         {!!links.length && (
           <div className="flex flex-wrap gap-3 pt-1">
             {links.map((l, i) => (
-              <a key={i} href={l.href} target="_blank" className="px-3 py-2 rounded-full border hover:bg-white dark:hover:bg-slate-800">
+              <PillLink key={i} href={l.href} external>
                 {l.label}
-              </a>
+              </PillLink>
             ))}
           </div>
         )}

--- a/components/ThemeToggle.jsx
+++ b/components/ThemeToggle.jsx
@@ -6,7 +6,7 @@ export default function ThemeToggle() {
   if (!mounted) return null;
   return (
     <button onClick={toggle} aria-label="Toggle theme"
-      className="px-3 py-2 rounded-full border hover:bg-white dark:hover:bg-slate-800 flex items-center gap-2">
+      className="pill-outline flex items-center gap-2">
       {dark ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
       <span className="hidden sm:inline">{dark ? "Light" : "Dark"}</span>
     </button>

--- a/components/ui/Badge.jsx
+++ b/components/ui/Badge.jsx
@@ -1,4 +1,18 @@
-export default function Badge({ children, className = "" }) {
-  return <span className={`badge ${className}`}>{children}</span>;
+export default function Badge({
+  children,
+  icon: Icon,
+  variant = 'solid',
+  className = '',
+}) {
+  const base = 'badge';
+  const variantClasses =
+    variant === 'outline' ? 'border bg-white dark:bg-slate-900' : '';
+  const gap = Icon ? 'gap-2' : '';
+  return (
+    <span className={`${base} ${variantClasses} ${gap} ${className}`.trim()}>
+      {Icon && <Icon className="w-4 h-4" />}
+      {children}
+    </span>
+  );
 }
 

--- a/components/ui/Card.jsx
+++ b/components/ui/Card.jsx
@@ -1,7 +1,25 @@
-export function Card({ children, className = "" }) {
-  return <div className={`card rounded-2xl border bg-white dark:bg-slate-900 ${className}`}>{children}</div>;
+export function Card({ children, className = '' }) {
+  return (
+    <div className={`card rounded-2xl border bg-white dark:bg-slate-900 ${className}`}>{children}</div>
+  );
 }
-export const CardHeader  = ({ children, className = "" }) => <div className={`px-6 pt-6 ${className}`}>{children}</div>;
-export const CardTitle   = ({ children, className = "" }) => <h3 className={`text-lg font-semibold ${className}`}>{children}</h3>;
-export const CardContent = ({ children, className = "" }) => <div className={`px-6 pb-6 pt-2 space-y-3 ${className}`}>{children}</div>;
+export const CardHeader = ({ children, action, className = '' }) => (
+  <div
+    className={`px-6 pt-6 ${action ? 'flex items-center justify-between' : ''} ${className}`.trim()}
+  >
+    {children}
+    {action}
+  </div>
+);
+export const CardTitle = ({ children, icon: Icon, className = '' }) => (
+  <h3
+    className={`text-lg font-semibold ${Icon ? 'flex items-center gap-2' : ''} ${className}`.trim()}
+  >
+    {Icon && <Icon className="w-5 h-5" />}
+    {children}
+  </h3>
+);
+export const CardContent = ({ children, className = '' }) => (
+  <div className={`px-6 pb-6 pt-2 space-y-3 ${className}`}>{children}</div>
+);
 

--- a/components/ui/PillLink.jsx
+++ b/components/ui/PillLink.jsx
@@ -1,0 +1,18 @@
+export default function PillLink({ href, children, icon: Icon, variant = 'outline', external = false, className = '' }) {
+  const base =
+    variant === 'solid'
+      ? 'pill bg-slate-900 text-white dark:bg-white dark:text-slate-900'
+      : 'pill-outline';
+  const classes = `${base} flex items-center gap-2 ${className}`.trim();
+  return (
+    <a
+      href={href}
+      target={external ? '_blank' : undefined}
+      rel={external ? 'noopener noreferrer' : undefined}
+      className={classes}
+    >
+      {Icon && <Icon className="w-4 h-4" />}
+      {children}
+    </a>
+  );
+}

--- a/components/ui/Section.jsx
+++ b/components/ui/Section.jsx
@@ -1,10 +1,10 @@
 export default function Section({ id, title, icon, children }) {
     const Icon = icon;
     return (
-	<section
-	   id={id}
-	    className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-10 scroll-mt-16"
-	>
+        <section
+           id={id}
+            className="section-container py-10 scroll-mt-16"
+        >
 	<div className="flex items-center gap-3 mb-6">
 	<div className="p-2 rounded-xl border bg-white dark:bg-slate-900 card">
 	<Icon className="w-5 h-5" />

--- a/components/ui/Stat.jsx
+++ b/components/ui/Stat.jsx
@@ -1,0 +1,10 @@
+export default function Stat({ value, label }) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-1">
+      <div className="text-3xl font-extrabold">{value}</div>
+      <div className="text-sm opacity-70 h-10 flex items-center justify-center text-center">
+        {label}
+      </div>
+    </div>
+  );
+}

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,524 +1,107 @@
 import Head from 'next/head';
-import ThemeToggle from '@/components/ThemeToggle';
-import Section from '@/components/ui/Section';
-import ProjectCard from '@/components/ProjectCard';
-import ExperienceItem from '@/components/ExperienceItem';
-import SkillsGrid from '@/components/SkillsGrid';
-import Badge from '@/components/ui/Badge';
-import BarSparkline from '@/components/ui/BarSparkline';
-import ActivityToggle from '@/components/ui/ActivityToggle';
-import SpotifyTopArtists from '@/components/SpotifyTopArtists';
-import SpotifyTopTracks from '@/components/SpotifyTopTracks';
-import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/Card';
-import { MapPin, Trophy, Briefcase, GraduationCap, Cpu, Brain, FileText, Github, Linkedin, Mail, Sparkles, BarChart, Target } from 'lucide-react';
-import { useEffect, useState, useMemo } from 'react';
 import rawProjects from '@/public/projects.json' assert { type: 'json' };
 import rawExperience from '@/public/experience.json' assert { type: 'json' };
 import { validateProjects } from '@/lib/projects';
 import { validateExperience } from '@/lib/experience';
+import Header from '@/components/Header';
+import Hero from '@/components/Hero';
+import AboutSection from '@/components/AboutSection';
+import Footer from '@/components/Footer';
+import ListSection from '@/components/ListSection';
+import Section from '@/components/ui/Section';
+import ProjectCard from '@/components/ProjectCard';
+import ExperienceItem from '@/components/ExperienceItem';
+import EducationItem from '@/components/EducationItem';
+import SkillsGrid from '@/components/SkillsGrid';
+import { Trophy, Briefcase, GraduationCap, Cpu } from 'lucide-react';
 
 const projects = validateProjects(rawProjects) ? rawProjects : [];
 const experience = validateExperience(rawExperience) ? rawExperience : [];
 
 const links = {
-    github: 'https://github.com/seanpatrickmay',
-    linkedin: 'https://linkedin.com/in/seanpatrickmay',
-    email: 'mailto:may.se@northeastern.edu',
-    resume: '/resume.pdf',
+  github: 'https://github.com/seanpatrickmay',
+  linkedin: 'https://linkedin.com/in/seanpatrickmay',
+  email: 'mailto:may.se@northeastern.edu',
+  resume: '/resume.pdf',
 };
 
 const skills = {
-    languages: ['Python','Java','C','JavaScript','HTML','CSS'],
-    tools: ['Git', 'PyTorch','NumPy','Neovim', 'Matplotlib','Jupyter','React'],
-    platforms: ['Windows','macOS','Ubuntu Linux'],
+  languages: ['Python', 'Java', 'C', 'JavaScript', 'HTML', 'CSS'],
+  tools: ['Git', 'PyTorch', 'NumPy', 'Neovim', 'Matplotlib', 'Jupyter', 'React'],
+  platforms: ['Windows', 'macOS', 'Ubuntu Linux'],
 };
 
 const education = [
-    {
-	school: 'Northeastern University — Khoury College of Computer Sciences',
-	degree: 'B.S. in Computer Science & Mathematics (Expected Dec 2026)',
-	extras: [
-	    'GPA 3.64/4.0; Dean’s Scholarship; Dean’s List (Fall 2024, Spring 2025)',
-	    'Activities: Bridge to Calculus Tutor, Calculus Field Day Volunteer, Math Club, Putnam Club, Running Club',
-	    'Relevant coursework: AI, Matrix Methods in ML, Algorithms & Data Structures, OOP, Computer Systems, Probability & Statistics',
-	],
-    },
-    {
-	school: 'Summer Study — Mathematical Heritage of Budapest',
-	degree: 'Budapest, Hungary (Jun – Aug 2025)',
-	extras: ['Courses: Number Theory, Exploration of Modern Mathematics'],
-    },
+  {
+    school: 'Northeastern University — Khoury College of Computer Sciences',
+    degree: 'B.S. in Computer Science & Mathematics (Expected Dec 2026)',
+    extras: [
+      'GPA 3.64/4.0; Dean’s Scholarship; Dean’s List (Fall 2024, Spring 2025)',
+      'Activities: Bridge to Calculus Tutor, Calculus Field Day Volunteer, Math Club, Putnam Club, Running Club',
+      'Relevant coursework: AI, Matrix Methods in ML, Algorithms & Data Structures, OOP, Computer Systems, Probability & Statistics',
+    ],
+  },
+  {
+    school: 'Summer Study — Mathematical Heritage of Budapest',
+    degree: 'Budapest, Hungary (Jun – Aug 2025)',
+    extras: ['Courses: Number Theory, Exploration of Modern Mathematics'],
+  },
 ];
 
 const interests = [
-    'Brain Teasers','Game Theory','Poker','Chess','Français','Track & Field','Triathlon','Skiing','Sports Science'
+  'Brain Teasers', 'Game Theory', 'Poker', 'Chess', 'Français', 'Track & Field', 'Triathlon', 'Skiing', 'Sports Science'
 ];
 
-function useStats() {
-  const [stats, setStats] = useState(null);
-  useEffect(() => {
-    fetch('/stats.json', { cache: 'no-cache' })
-      .then(r => (r.ok ? r.json() : null))
-      .then(setStats)
-      .catch(() => setStats(null));
-  }, []);
-  return stats;
-}
-
-function useSpotify() {
-  const [data, setData] = useState(null);
-  useEffect(() => {
-    fetch('/spotify.json', { cache: 'no-cache' })
-      .then(r => (r.ok ? r.json() : null))
-      .then(setData)
-      .catch(() => setData(null));
-  }, []);
-  return data;
-}
-
-function AboutStat({ icon: Icon, label, value, hint }) {
-    return (
-	<Card className="transition hover:shadow-md">
-	<CardContent className="pt-6">
-	<div className="flex items-center justify-between">
-	<div>
-	<div className="text-3xl font-extrabold tracking-tight">{value}</div>
-	<div className="text-sm opacity-70 mt-1">{label}</div>
-	</div>
-	<div className="p-2 rounded-xl border bg-white dark:bg-slate-900">
-	<Icon className="w-5 h-5" />
-	</div>
-	</div>
-	{hint ? <div className="text-xs opacity-60 mt-3">{hint}</div> : null}
-	</CardContent>
-	</Card>
-    );
-}
-
-function AboutMe() {
-  const stats = useStats();
-  const spotify = useSpotify();
-  const [activity, setActivity] = useState("combined");
-
-  const data = stats?.stats?.[activity];
-  const monthly = data?.monthly;
-  const series = data?.weekly?.series ?? [];
-
-  const weeklyValues = useMemo(
-    () => series.map(w => w.distance_km),
-    [series]
-  );
-
-      // use previous week for "last" value (current week is still in progress)
-  const lastWeek = weeklyValues.length > 1 ? weeklyValues.at(-2) : undefined;
-  const bestWeek = weeklyValues.length ? Math.max(...weeklyValues) : undefined;
-  const generatedAt = stats ? new Date(stats.generated_at) : null;
-  // display updated time slightly behind the actual generated time, varying by day
-  const updatedAt = generatedAt
-    ? new Date(
-        generatedAt.getTime() -
-          (10 - (generatedAt.getDate() % 11)) * 60 * 1000
-      )
-    : null;
-  return (
-    <section id="about" className="relative scroll-mt-16">
-      {/* Soft radial accent */}
-      <div
-        aria-hidden
-        className="pointer-events-none absolute inset-0 -z-10 opacity-30 dark:opacity-20"
-        style={{
-          background:
-            'radial-gradient(60% 40% at 50% 20%, rgba(15,23,42,0.08), transparent 60%)'
-        }}
-      />
-      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-14 space-y-10">
-
-        {/* Deeper bio (distinct from hero) */}
-        <div className="grid md:grid-cols-5 gap-8 items-start">
-          <div className="md:col-span-3 space-y-5">
-            <div className="inline-flex items-center gap-2 text-sm px-3 py-1 rounded-full border bg-white dark:bg-slate-900">
-              <Sparkles className="w-4 h-4" />
-              <span>About me</span>
-            </div>
-            <h2 className="text-3xl md:text-4xl font-extrabold tracking-tight">
-              I learn by building — from algorithms to UX.
-            </h2>
-            <p className="text-lg text-slate-600 dark:text-slate-300">
-              My sweet spot is where CS fundamentals meet practical impact. I’ve built
-              projects across computer vision, game-theoretic search, and systems-level C,
-              and I enjoy shaping ideas into reliable, maintainable software.
-            </p>
-          </div>
-
-          {/* Interests moved here (no longer in hero) */}
-          <div className="md:col-span-2">
-            <Card>
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2">
-                  <Brain className="w-5 h-5" /> Interests
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="flex flex-wrap gap-2">
-                  {interests.map(i => <Badge key={i}>{i}</Badge>)}
-                </div>
-              </CardContent>
-            </Card>
-          </div>
-        </div>
-
-        {/* Part-Time Work */}
-        <div className="grid md:grid-cols-3 gap-6">
-          {/* Part-Time Work */}
-          <Card className="md:col-span-2">
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <Target className="w-5 h-5" /> Part-Time Work
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <ul className="list-disc pl-5 space-y-2">
-                <li><strong>Semi-Professional Poker (NLHE)</strong> — probabilistic reasoning, risk management, and disciplined decision-making.</li>
-                <li><strong>Computer Science Tutor (CSA)</strong> — mentoring on fundamentals, debugging strategies, and problem-solving patterns.</li>
-              </ul>
-            </CardContent>
-          </Card>
-	</div>
-
-	{/* Training stats */}
-        <div className="grid md:grid-cols-3 gap-6">
-          {/* Monthly */}
-          <Card className="md:col-span-2">
-            <CardHeader className="flex items-center justify-between">
-              <CardTitle>
-                Monthly Training (last {monthly?.window_days ?? 30} days)
-              </CardTitle>
-	      <ActivityToggle activity={activity} onChange={setActivity} />
-            </CardHeader>
-            <CardContent className="grid sm:grid-cols-3 gap-4">
-              <div className="flex flex-col items-center justify-center gap-1">
-                <div className="text-3xl font-extrabold">
-		    {monthly ? monthly.distance_km : "—"}
-                </div>
-                <div className="text-sm opacity-70 h-10 flex items-center justify-center text-center">
-		    Total distance (km)
-		</div>
-              </div>
-              <div className="flex flex-col items-center justify-center gap-1">
-                <div className="text-3xl font-extrabold">
-                  {monthly?.time_hours ?? "—"}
-                </div>
-                <div className="text-sm opacity-70 h-10 flex items-center justify-center">
-		    Total hours
-		</div>
-              </div>
-              <div className="flex flex-col items-center justify-center gap-1">
-                <div className="text-3xl font-extrabold">
-                  {monthly?.activities_count ?? "—"}
-                </div>
-                <div className="text-sm opacity-70 h-10 flex items-center justify-center">
-		    Activities
-		</div>
-              </div>
-              {monthly && updatedAt && (
-                <div className="sm:col-span-3 text-sm opacity-70 text-center">
-                  Longest:{" "}
-		  {monthly.longest_km} km · Updated{" "}
-                </div>
-              )}
-            </CardContent>
-          </Card>
-
-          {/* Recent */}
-          <Card>
-            <CardHeader>
-              <CardTitle>Recent</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <ul className="space-y-3">
-                {(data?.recent?.last3 ?? []).map((a) => (
-                  <li
-                    key={a.id}
-                    className="flex items-start justify-between gap-3"
-                  >
-                    <div className="min-w-0">
-                      <div className="font-medium truncate">
-                        {a.name || a.type || "Activity"}
-                      </div>
-                      <div className="text-xs opacity-70">{a.start}</div>
-                    </div>
-                    <div className="text-right shrink-0">
-                      <div className="text-sm">
-			{a.distance_km} km
-                      </div>
-                      <div className="text-xs opacity-70">{a.duration_min} min</div>
-                    </div>
-                  </li>
-                ))}
-                {!data?.recent?.last3?.length && (
-                  <div className="text-sm opacity-70">No recent activities</div>
-                )}
-              </ul>
-            </CardContent>
-          </Card>
-        </div>
-
-        {/* Weekly Sparkline */}
-	{/* Weekly charts: Hours (left) + Distance (right) */}
-<Card>
-  <CardHeader className="flex items-center justify-between">
-    <CardTitle className="flex items-center gap-2">
-      Weekly Training
-      {weeklyValues.length > 1 && (
-        <span className="text-sm opacity-70">
-          • last:{" "}
-          <strong>
-            {typeof lastWeek === "number" ? lastWeek.toFixed(1) : "—"}
-          </strong>{" "}km
-        </span>
-      )}
-    </CardTitle>
-      <ActivityToggle activity={activity} onChange={setActivity} />
-  </CardHeader>
-
-  <CardContent>
-    {series.length ? (
-      <div className="grid md:grid-cols-2 gap-6 text-slate-900 dark:text-slate-100">
-        {/* LEFT: Hours */}
-        <div>
-          <div className="flex items-center justify-between mb-2">
-            <div className="text-sm font-medium opacity-80">Hours</div>
-          </div>
-          <BarSparkline
-            values={series.map(w => w.time_hours)}
-            formatter={(v, i) => {
-              const w = series[i];
-              const label = w ? `${w.week_start} → ${w.week_end}` : `Week ${i + 1}`;
-              return `${label}: ${v.toFixed(2)} h`;
-            }}
-          />
-        </div>
-
-        {/* RIGHT: Distance (mi|km toggle) */}
-        <div>
-          <div className="flex items-center justify-between mb-2">
-            <div className="text-sm font-medium opacity-80">
-              Distance (km)
-            </div>
-          </div>
-          <BarSparkline
-            values={series.map(w => w.distance_km)}
-            formatter={(v, i) => {
-              const w = series[i];
-              const label = w ? `${w.week_start} → ${w.week_end}` : `Week ${i + 1}`;
-              return `${label}: ${v.toFixed(1)} km`;
-            }}
-          />
-        </div>
-      </div>
-    ) : (
-      <div className="text-sm opacity-70">No weekly data yet</div>
-    )}
-
-    {/* Best week footnote */}
-    {weeklyValues.length ? (
-      <div className="mt-3 text-xs opacity-70">
-        Best distance week:{" "}
-        {typeof bestWeek === "number" ? bestWeek.toFixed(1) : "—"} km ·
-        Updated {stats ? new Date(stats.generated_at).toLocaleDateString() : "—"}
-      </div>
-    ) : null}
-	</CardContent>
-        </Card>
-      {/* Spotify listening */}
-        <div className="grid md:grid-cols-3 gap-6">
-          <Card className="md:col-span-2">
-            <CardHeader>
-              <CardTitle>Top Artists</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <SpotifyTopArtists artists={spotify?.artists ?? []} />
-            </CardContent>
-          </Card>
-          <Card>
-            <CardHeader>
-              <CardTitle>Top Tracks</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <SpotifyTopTracks tracks={spotify?.tracks ?? []} />
-            </CardContent>
-          </Card>
-        </div>
-      </div>
-    </section>
-  );
-}
-
-// -----------------------------------------------------------------------------
-
 export default function Home() {
-    return (
-	<>
-	<Head>
-	<title>Sean P. May — Portfolio</title>
-	<meta
-	name="description"
-	content="Projects, experience, and education of Sean P. May (CS/Math, Northeastern University)."
-	/>
-	<link
-	rel="icon"
-	href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>👽</text></svg>"
-	/>
-	</Head>
+  return (
+    <>
+      <Head>
+        <title>Sean P. May — Portfolio</title>
+        <meta
+          name="description"
+          content="Projects, experience, and education of Sean P. May (CS/Math, Northeastern University)."
+        />
+        <link
+          rel="icon"
+          href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>👽</text></svg>"
+        />
+      </Head>
 
-	<header className="sticky top-0 z-20 backdrop-blur border-b bg-white/70 dark:bg-slate-900/70 dark:border-slate-800">
-	<div className="max-w-5xl mx-auto flex items-center justify-between px-4 sm:px-6 lg:px-8 h-16">
-	<a href="#home" className="font-bold tracking-tight text-xl">Sean P. May</a>
-	<nav className="hidden sm:flex items-center gap-2">
-	{['about','projects','experience','education','skills'].map(id => (
-	    <a
-	    key={id}
-	    href={`#${id}`}
-	    className="px-3 py-2 rounded-full hover:bg-slate-100 dark:hover:bg-slate-800 capitalize"
-	    >
-	    {id}
-	    </a>
-	))}
-	<a
-	href={links.resume}
-	target="_blank"
-	className="px-3 py-2 rounded-full border hover:bg-white dark:hover:bg-slate-800 flex items-center gap-2"
-	>
-	<FileText className="w-4 h-4" /> Resume
-	</a>
-	<ThemeToggle />
-	</nav>
-	</div>
-	</header>
+      <Header links={links} />
+      <Hero links={links} />
+      <AboutSection interests={interests} />
 
-	{/* HERO — concise, no overlap with About */}
-	<section id="home" className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-16 scroll-mt-16">
-	<div className="grid md:grid-cols-5 gap-8 items-center">
-	<div className="md:col-span-3 space-y-5">
-	<div className="inline-flex items-center gap-2 text-sm px-3 py-1 rounded-full border bg-white dark:bg-slate-900">
-	<MapPin className="w-4 h-4" />
-	<span>Boston, MA</span>
-	</div>
-	<h1 className="text-4xl md:text-5xl font-extrabold tracking-tight">
-	CS/Math engineer building ML + systems projects
-	</h1>
-	<p className="text-lg text-slate-600 dark:text-slate-300 max-w-2xl">
-	I design and ship clean, usable software — from low-level C to applied ML.
-	</p>
+      <ListSection
+        id="projects"
+        title="Projects"
+        icon={Trophy}
+        items={projects}
+        columns={2}
+        renderItem={p => <ProjectCard key={p.title} project={p} />}
+      />
 
-	{/* Quick facts (kept short) */}
-	<ul className="text-sm text-slate-600 dark:text-slate-300 space-y-1">
-	<li>🎓 Northeastern University — B.S. CS & Math (May 2027)</li>
-	<li>🧪 Incoming: NExT Program SWE Co-op (Fall 2025)</li>
-	<li>🔎 Open to Summer/Fall 2026 SWE/ML roles</li>
-	</ul>
+      <ListSection
+        id="experience"
+        title="Experience"
+        icon={Briefcase}
+        items={experience}
+        renderItem={job => <ExperienceItem key={job.org} job={job} />}
+      />
 
-	<div className="flex flex-wrap gap-3 pt-2">
-	<a href="#projects" className="px-4 py-2 rounded-full bg-slate-900 text-white dark:bg-white dark:text-slate-900">
-	See projects
-	</a>
-	<a href={links.github} target="_blank" className="px-4 py-2 rounded-full border">GitHub</a>
-	<a href={links.linkedin} target="_blank" className="px-4 py-2 rounded-full border">LinkedIn</a>
-	<a href={links.email} className="px-4 py-2 rounded-full">Contact</a>
-	</div>
-	</div>
+      <ListSection
+        id="education"
+        title="Education"
+        icon={GraduationCap}
+        items={education}
+        renderItem={e => <EducationItem key={e.school} item={e} />}
+      />
 
-	{/* Right column: compact summary card (no interests here) */}
-	<div className="md:col-span-2">
-	<Card>
-	<CardHeader>
-	<CardTitle className="flex items-center gap-2">
-	<Brain className="w-5 h-5" /> Snapshot
-	</CardTitle>
-	</CardHeader>
-	<CardContent className="space-y-2">
-	<div className="flex flex-wrap gap-2">
-	<Badge>ML</Badge>
-	<Badge>Systems</Badge>
-	<Badge>Full-stack</Badge>
-	</div>
-	<p className="text-sm text-slate-600 dark:text-slate-300">
-	Focused on game theory, computer vision, and performance-minded code.
-	</p>
-	<a
-	href={links.resume}
-	target="_blank"
-	className="inline-flex items-center gap-2 px-3 py-2 rounded-full border hover:bg-white dark:hover:bg-slate-800"
-	>
-	<FileText className="w-4 h-4" /> Resume
-	</a>
-	</CardContent>
-	</Card>
-	</div>
-	</div>
-	</section>
-
-	{/* New, expanded About section */}
-	<AboutMe />
-	        {/* Projects */}
-        <Section id="projects" title="Projects" icon={Trophy}>
-        <div className="grid md:grid-cols-2 gap-6">
-        {projects.map(p => <ProjectCard key={p.title} project={p} />)}
-        </div>
-        </Section>
-	{/* Experience (render your entries via ExperienceItem) */}
-        <Section id="experience" title="Experience" icon={Briefcase}>
-        <div className="grid gap-6">
-        {experience.map((job) => <ExperienceItem key={job.org} job={job} />)}
-        </div>
-        </Section>
-	{/* Education */}
-        <Section id="education" title="Education" icon={GraduationCap}>
-        <div className="grid gap-6">
-        {education.map(e => (
-	    <Card key={e.school}>
-	    <CardHeader>
-	    <CardTitle>{e.school}</CardTitle>
-	    <div className="text-sm opacity-70">{e.degree}</div>
-	    </CardHeader>
-	    <CardContent>
-	    <ul className="list-disc pl-5 space-y-2">
-	    {e.extras.map((x, i) => <li key={i}>{x}</li>)}
-	    </ul>
-	    </CardContent>
-	    </Card>
-	))}
-	</div>
-	</Section>
-
-	{/* Skills (updated to resume) */}
-        <Section id="skills" title="Skills" icon={Cpu}>
-        <div>
+      <Section id="skills" title="Skills" icon={Cpu}>
         <SkillsGrid skills={skills} />
-        </div>
-        </Section>
+      </Section>
 
-	<footer className="border-t dark:border-slate-800 py-10 mt-10">
-	<div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center justify-between">
-	<p className="text-sm opacity-70">
-	© {new Date().getFullYear()} Sean P. May. All rights reserved.
-	</p>
-	<div className="flex gap-3">
-	<a href={links.github} target="_blank" className="px-3 py-2 rounded-full border hover:bg-white dark:hover:bg-slate-800 flex items-center gap-2">
-	<Github className="w-4 h-4" /> GitHub
-	</a>
-	<a href={links.linkedin} target="_blank" className="px-3 py-2 rounded-full border hover:bg-white dark:hover:bg-slate-800 flex items-center gap-2">
-	<Linkedin className="w-4 h-4" /> LinkedIn
-	</a>
-	<a href={links.email} className="px-3 py-2 rounded-full border hover:bg-white dark:hover:bg-slate-800 flex items-center gap-2">
-	<Mail className="w-4 h-4" /> Email
-	</a>
-	<a href={links.resume} target="_blank" className="px-3 py-2 rounded-full bg-slate-900 text-white dark:bg-white dark:text-slate-900 flex items-center gap-2">
-	<FileText className="w-4 h-4" /> Resume
-	</a>
-	</div>
-	</div>
-	</footer>
-	</>
-    );
+      <Footer links={links} />
+    </>
+  );
 }
+

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -14,6 +14,9 @@ body { @apply bg-gradient-to-b from-white to-slate-50 text-slate-900; }
 /* Shared */
 .card { box-shadow: 0 1px 3px rgba(0,0,0,.08), 0 1px 2px rgba(0,0,0,.06); }
 .badge { @apply inline-flex items-center px-3 py-1 rounded-full text-sm bg-slate-100; }
+.pill { @apply px-3 py-2 rounded-full; }
+.pill-outline { @apply pill border hover:bg-white dark:hover:bg-slate-800; }
+.section-container { @apply max-w-5xl mx-auto px-4 sm:px-6 lg:px-8; }
 
 /* Hide scrollbars but allow scrolling */
 .no-scrollbar {


### PR DESCRIPTION
## Summary
- add icon-aware `Badge` variants to remove inline label markup
- extend `CardHeader` and `CardTitle` with `action` and `icon` props and apply across hero and about sections
- extract reusable `Stat` component to cut repetition in training metrics

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b08a3a06a8832a8ab2df9e2284e7c7