### PR TITLE
Reorganize layout and split part-time work into Other Work section

### DIFF
--- a/components/AboutSection.jsx
+++ b/components/AboutSection.jsx
@@ -5,8 +5,9 @@ import BarSparkline from '@/components/ui/BarSparkline';
 import SpotifyTopArtists from '@/components/SpotifyTopArtists';
 import SpotifyTopTracks from '@/components/SpotifyTopTracks';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/Card';
+import Section from '@/components/ui/Section';
 import Stat from '@/components/ui/Stat';
-import { Sparkles, Brain, Target } from 'lucide-react';
+import { Sparkles, Brain, Dumbbell, Music } from 'lucide-react';
 
 function useStats() {
   const [stats, setStats] = useState(null);
@@ -39,204 +40,182 @@ export default function AboutSection({ interests }) {
   const monthly = data?.monthly;
   const series = data?.weekly?.series ?? [];
 
-  const weeklyValues = useMemo(
-    () => series.map(w => w.distance_km),
-    [series]
-  );
+  const weeklyValues = useMemo(() => series.map(w => w.distance_km), [series]);
 
   const lastWeek = weeklyValues.length > 1 ? weeklyValues.at(-2) : undefined;
   const bestWeek = weeklyValues.length ? Math.max(...weeklyValues) : undefined;
   const generatedAt = stats ? new Date(stats.generated_at) : null;
   const updatedAt = generatedAt
-    ? new Date(
-        generatedAt.getTime() -
-          (10 - (generatedAt.getDate() % 11)) * 60 * 1000
-      )
+    ? new Date(generatedAt.getTime() - (10 - (generatedAt.getDate() % 11)) * 60 * 1000)
     : null;
 
   return (
-    <section id="about" className="relative scroll-mt-16">
-      <div
-        aria-hidden
-        className="pointer-events-none absolute inset-0 -z-10 opacity-30 dark:opacity-20"
-        style={{
-          background:
-            'radial-gradient(60% 40% at 50% 20%, rgba(15,23,42,0.08), transparent 60%)'
-        }}
-      />
-      <div className="section-container py-14 space-y-10">
-        <div className="grid md:grid-cols-5 gap-8 items-start">
-          <div className="md:col-span-3 space-y-5">
-            <Badge icon={Sparkles} variant="outline">
-              About me
-            </Badge>
-            <h2 className="text-3xl md:text-4xl font-extrabold tracking-tight">
-              I learn by building — from algorithms to UX.
-            </h2>
-            <p className="text-lg text-slate-600 dark:text-slate-300">
-              My sweet spot is where CS fundamentals meet practical impact. I’ve built
-              projects across computer vision, game-theoretic search, and systems-level C,
-              and I enjoy shaping ideas into reliable, maintainable software.
-            </p>
+    <Section id="about" title="About me" icon={Sparkles}>
+      <div className="relative">
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-0 -z-10 opacity-30 dark:opacity-20"
+          style={{
+            background: 'radial-gradient(60% 40% at 50% 20%, rgba(15,23,42,0.08), transparent 60%)'
+          }}
+        />
+        <div className="space-y-12">
+          <div className="grid md:grid-cols-5 gap-8 items-start">
+            <div className="md:col-span-3 space-y-4">
+              <p className="text-lg text-slate-600 dark:text-slate-300">
+                I'm a CS & math student who builds things, trains hard, and always has music playing.
+              </p>
+            </div>
+            <div className="md:col-span-2">
+              <Card>
+                <CardHeader>
+                  <CardTitle icon={Brain}>Interests</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="flex flex-wrap gap-2">
+                    {interests.map(i => (
+                      <Badge key={i}>{i}</Badge>
+                    ))}
+                  </div>
+                </CardContent>
+              </Card>
+            </div>
           </div>
 
-          <div className="md:col-span-2">
+          <div className="space-y-6">
+            <div className="space-y-2">
+              <h3 className="flex items-center gap-2 text-2xl font-semibold">
+                <Dumbbell className="w-5 h-5" />
+                Training
+              </h3>
+              <p className="text-slate-600 dark:text-slate-300">Snapshot of recent workouts.</p>
+            </div>
+            <div className="grid md:grid-cols-3 gap-6">
+              <Card className="md:col-span-2">
+                <CardHeader action={<ActivityToggle activity={activity} onChange={setActivity} />}>
+                  <CardTitle>Monthly Training (last {monthly?.window_days ?? 30} days)</CardTitle>
+                </CardHeader>
+                <CardContent className="grid sm:grid-cols-3 gap-4">
+                  <Stat value={monthly ? monthly.distance_km : '—'} label="Total distance (km)" />
+                  <Stat value={monthly?.time_hours ?? '—'} label="Total hours" />
+                  <Stat value={monthly?.activities_count ?? '—'} label="Activities" />
+                  {monthly && updatedAt && (
+                    <div className="sm:col-span-3 text-sm opacity-70 text-center">
+                      Longest: {monthly.longest_km} km · Updated{' '}
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
+
+              <Card>
+                <CardHeader>
+                  <CardTitle>Recent</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <ul className="space-y-3">
+                    {(data?.recent?.last3 ?? []).map(a => (
+                      <li key={a.id} className="flex items-start justify-between gap-3">
+                        <div className="min-w-0">
+                          <div className="font-medium truncate">{a.name || a.type || 'Activity'}</div>
+                          <div className="text-xs opacity-70">{a.start}</div>
+                        </div>
+                        <div className="text-right shrink-0">
+                          <div className="text-sm">{a.distance_km} km</div>
+                          <div className="text-xs opacity-70">{a.duration_min} min</div>
+                        </div>
+                      </li>
+                    ))}
+                    {!data?.recent?.last3?.length && (
+                      <div className="text-sm opacity-70">No recent activities</div>
+                    )}
+                  </ul>
+                </CardContent>
+              </Card>
+            </div>
+
             <Card>
-              <CardHeader>
-                <CardTitle icon={Brain}>Interests</CardTitle>
+              <CardHeader action={<ActivityToggle activity={activity} onChange={setActivity} />}>
+                <CardTitle className="flex items-center gap-2">
+                  Weekly Training
+                  {weeklyValues.length > 1 && (
+                    <span className="text-sm opacity-70">
+                      • last: <strong>{typeof lastWeek === 'number' ? lastWeek.toFixed(1) : '—'}</strong> km
+                    </span>
+                  )}
+                </CardTitle>
               </CardHeader>
               <CardContent>
-                <div className="flex flex-wrap gap-2">
-                  {interests.map(i => <Badge key={i}>{i}</Badge>)}
-                </div>
+                {series.length ? (
+                  <div className="grid md:grid-cols-2 gap-6 text-slate-900 dark:text-slate-100">
+                    <div>
+                      <div className="flex items-center justify-between mb-2">
+                        <div className="text-sm font-medium opacity-80">Hours</div>
+                      </div>
+                      <BarSparkline
+                        values={series.map(w => w.time_hours)}
+                        formatter={(v, i) => {
+                          const w = series[i];
+                          const label = w ? `${w.week_start} → ${w.week_end}` : `Week ${i + 1}`;
+                          return `${label}: ${v.toFixed(2)} h`;
+                        }}
+                      />
+                    </div>
+                    <div>
+                      <div className="flex items-center justify-between mb-2">
+                        <div className="text-sm font-medium opacity-80">Distance (km)</div>
+                      </div>
+                      <BarSparkline
+                        values={series.map(w => w.distance_km)}
+                        formatter={(v, i) => {
+                          const w = series[i];
+                          const label = w ? `${w.week_start} → ${w.week_end}` : `Week ${i + 1}`;
+                          return `${label}: ${v.toFixed(1)} km`;
+                        }}
+                      />
+                    </div>
+                  </div>
+                ) : (
+                  <div className="text-sm opacity-70">No weekly data yet</div>
+                )}
+                {weeklyValues.length ? (
+                  <div className="mt-3 text-xs opacity-70">
+                    Best distance week: {typeof bestWeek === 'number' ? bestWeek.toFixed(1) : '—'} km · Updated {stats ? new Date(stats.generated_at).toLocaleDateString() : '—'}
+                  </div>
+                ) : null}
               </CardContent>
             </Card>
           </div>
-        </div>
 
-        <div className="grid md:grid-cols-3 gap-6">
-          <Card className="md:col-span-2">
-            <CardHeader>
-              <CardTitle icon={Target}>Part-Time Work</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <ul className="list-disc pl-5 space-y-2">
-                <li><strong>Semi-Professional Poker (NLHE)</strong> — probabilistic reasoning, risk management, and disciplined decision-making.</li>
-                <li><strong>Computer Science Tutor (CSA)</strong> — mentoring on fundamentals, debugging strategies, and problem-solving patterns.</li>
-              </ul>
-            </CardContent>
-          </Card>
-        </div>
-
-        <div className="grid md:grid-cols-3 gap-6">
-          <Card className="md:col-span-2">
-            <CardHeader action={<ActivityToggle activity={activity} onChange={setActivity} />}>
-              <CardTitle>
-                Monthly Training (last {monthly?.window_days ?? 30} days)
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="grid sm:grid-cols-3 gap-4">
-              <Stat
-                value={monthly ? monthly.distance_km : '—'}
-                label="Total distance (km)"
-              />
-              <Stat
-                value={monthly?.time_hours ?? '—'}
-                label="Total hours"
-              />
-              <Stat
-                value={monthly?.activities_count ?? '—'}
-                label="Activities"
-              />
-              {monthly && updatedAt && (
-                <div className="sm:col-span-3 text-sm opacity-70 text-center">
-                  Longest: {monthly.longest_km} km · Updated{' '}
-                </div>
-              )}
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <CardTitle>Recent</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <ul className="space-y-3">
-                {(data?.recent?.last3 ?? []).map(a => (
-                  <li key={a.id} className="flex items-start justify-between gap-3">
-                    <div className="min-w-0">
-                      <div className="font-medium truncate">
-                        {a.name || a.type || 'Activity'}
-                      </div>
-                      <div className="text-xs opacity-70">{a.start}</div>
-                    </div>
-                    <div className="text-right shrink-0">
-                      <div className="text-sm">{a.distance_km} km</div>
-                      <div className="text-xs opacity-70">{a.duration_min} min</div>
-                    </div>
-                  </li>
-                ))}
-                {!data?.recent?.last3?.length && (
-                  <div className="text-sm opacity-70">No recent activities</div>
-                )}
-              </ul>
-            </CardContent>
-          </Card>
-        </div>
-
-        <Card>
-          <CardHeader action={<ActivityToggle activity={activity} onChange={setActivity} />}>
-            <CardTitle className="flex items-center gap-2">
-              Weekly Training
-              {weeklyValues.length > 1 && (
-                <span className="text-sm opacity-70">
-                  • last: <strong>{typeof lastWeek === 'number' ? lastWeek.toFixed(1) : '—'}</strong> km
-                </span>
-              )}
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            {series.length ? (
-              <div className="grid md:grid-cols-2 gap-6 text-slate-900 dark:text-slate-100">
-                <div>
-                  <div className="flex items-center justify-between mb-2">
-                    <div className="text-sm font-medium opacity-80">Hours</div>
-                  </div>
-                  <BarSparkline
-                    values={series.map(w => w.time_hours)}
-                    formatter={(v, i) => {
-                      const w = series[i];
-                      const label = w ? `${w.week_start} → ${w.week_end}` : `Week ${i + 1}`;
-                      return `${label}: ${v.toFixed(2)} h`;
-                    }}
-                  />
-                </div>
-                <div>
-                  <div className="flex items-center justify-between mb-2">
-                    <div className="text-sm font-medium opacity-80">Distance (km)</div>
-                  </div>
-                  <BarSparkline
-                    values={series.map(w => w.distance_km)}
-                    formatter={(v, i) => {
-                      const w = series[i];
-                      const label = w ? `${w.week_start} → ${w.week_end}` : `Week ${i + 1}`;
-                      return `${label}: ${v.toFixed(1)} km`;
-                    }}
-                  />
-                </div>
-              </div>
-            ) : (
-              <div className="text-sm opacity-70">No weekly data yet</div>
-            )}
-            {weeklyValues.length ? (
-              <div className="mt-3 text-xs opacity-70">
-                Best distance week: {typeof bestWeek === 'number' ? bestWeek.toFixed(1) : '—'} km ·
-                Updated {stats ? new Date(stats.generated_at).toLocaleDateString() : '—'}
-              </div>
-            ) : null}
-          </CardContent>
-        </Card>
-
-        <div className="grid md:grid-cols-3 gap-6">
-          <Card className="md:col-span-2">
-            <CardHeader>
-              <CardTitle>Top Artists</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <SpotifyTopArtists artists={spotify?.artists ?? []} />
-            </CardContent>
-          </Card>
-          <Card>
-            <CardHeader>
-              <CardTitle>Top Tracks</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <SpotifyTopTracks tracks={spotify?.tracks ?? []} />
-            </CardContent>
-          </Card>
+          <div className="space-y-6">
+            <div className="space-y-2">
+              <h3 className="flex items-center gap-2 text-2xl font-semibold">
+                <Music className="w-5 h-5" />
+                Music
+              </h3>
+              <p className="text-slate-600 dark:text-slate-300">A peek at what I'm listening to.</p>
+            </div>
+            <div className="grid md:grid-cols-3 gap-6">
+              <Card className="md:col-span-2">
+                <CardHeader>
+                  <CardTitle>Top Artists</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <SpotifyTopArtists artists={spotify?.artists ?? []} />
+                </CardContent>
+              </Card>
+              <Card>
+                <CardHeader>
+                  <CardTitle>Top Tracks</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <SpotifyTopTracks tracks={spotify?.tracks ?? []} />
+                </CardContent>
+              </Card>
+            </div>
+          </div>
         </div>
       </div>
-    </section>
+    </Section>
   );
 }
 

--- a/lib/work.js
+++ b/lib/work.js
@@ -1,0 +1,9 @@
+export function validateWork(arr) {
+    return Array.isArray(arr) && arr.every(p =>
+        typeof p.org == "string" &&
+        typeof p.role == "string" &&
+        typeof p.location == "string" &&
+        typeof p.period == "string" &&
+        Array.isArray(p.bullets)
+    );
+}

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,8 +1,10 @@
 import Head from 'next/head';
 import rawProjects from '@/public/projects.json' assert { type: 'json' };
 import rawExperience from '@/public/experience.json' assert { type: 'json' };
+import rawOtherWork from '@/public/other-work.json' assert { type: 'json' };
 import { validateProjects } from '@/lib/projects';
 import { validateExperience } from '@/lib/experience';
+import { validateWork } from '@/lib/work';
 import Header from '@/components/Header';
 import Hero from '@/components/Hero';
 import AboutSection from '@/components/AboutSection';
@@ -13,10 +15,11 @@ import ProjectCard from '@/components/ProjectCard';
 import ExperienceItem from '@/components/ExperienceItem';
 import EducationItem from '@/components/EducationItem';
 import SkillsGrid from '@/components/SkillsGrid';
-import { Trophy, Briefcase, GraduationCap, Cpu } from 'lucide-react';
+import { Trophy, Briefcase, GraduationCap, Cpu, ClipboardList } from 'lucide-react';
 
 const projects = validateProjects(rawProjects) ? rawProjects : [];
 const experience = validateExperience(rawExperience) ? rawExperience : [];
+const otherWork = validateWork(rawOtherWork) ? rawOtherWork : [];
 
 const links = {
   github: 'https://github.com/seanpatrickmay',
@@ -72,20 +75,28 @@ export default function Home() {
       <AboutSection interests={interests} />
 
       <ListSection
+        id="experience"
+        title="Experience"
+        icon={Briefcase}
+        items={experience}
+        renderItem={job => <ExperienceItem key={job.org} job={job} />}
+      />
+
+      <ListSection
+        id="other-work"
+        title="Other Work"
+        icon={ClipboardList}
+        items={otherWork}
+        renderItem={job => <ExperienceItem key={job.org} job={job} />}
+      />
+
+      <ListSection
         id="projects"
         title="Projects"
         icon={Trophy}
         items={projects}
         columns={2}
         renderItem={p => <ProjectCard key={p.title} project={p} />}
-      />
-
-      <ListSection
-        id="experience"
-        title="Experience"
-        icon={Briefcase}
-        items={experience}
-        renderItem={job => <ExperienceItem key={job.org} job={job} />}
       />
 
       <ListSection

--- a/public/experience.json
+++ b/public/experience.json
@@ -5,9 +5,9 @@
     "location": "Boston, MA",
     "period": "Expected Sep. - Dec. 2025",
     "bullets": [
-	"Building real-world software with peers in an agile, consulting-style team for Northeastern's industry partners.",
-	"Taking full ownership of projects, from design to coding, testing, and client demonstrations.",
-	"Gaining startup-like experience by rotating technical roles, and working directly with clients."
+      "Building real-world software with peers in an agile, consulting-style team for Northeastern's industry partners.",
+      "Taking full ownership of projects, from design to coding, testing, and client demonstrations.",
+      "Gaining startup-like experience by rotating technical roles, and working directly with clients."
     ]
   },
   {

--- a/public/other-work.json
+++ b/public/other-work.json
@@ -1,0 +1,21 @@
+[
+  {
+    "org": "Self-Employed",
+    "role": "Semi-Professional Poker (NLHE)",
+    "location": "Remote",
+    "period": "Part-time",
+    "bullets": [
+      "Applied probabilistic reasoning and risk management in competitive play.",
+      "Tracked results and reviewed hands to improve decision-making."
+    ]
+  },
+  {
+    "org": "Northeastern University",
+    "role": "Computer Science Tutor (CSA)",
+    "location": "Boston, MA",
+    "period": "Sep 2024 – Present",
+    "bullets": [
+      "Mentor students on fundamentals, debugging strategies, and problem-solving patterns."
+    ]
+  }
+]


### PR DESCRIPTION
## Summary
- Tweak About intro and add icons for training and music subsections
- Reorder homepage flow and move part-time work to dedicated Other Work section
- Append poker and tutoring entries to other-work data and keep Experience focused on co-ops

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b10b9cd2a0832a93123b595f35a7f9