### PR TITLE
chore: ensure deployment runs on automated updates

### DIFF
--- a/.github/workflows/update-spotify.yml
+++ b/.github/workflows/update-spotify.yml
@@ -40,7 +40,7 @@ jobs:
             git config user.name "github-actions[bot]"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git add public/spotify.json
-            git commit -m "chore(spotify): daily refresh [skip ci]"
+            git commit -m "chore(spotify): daily refresh"
             git push
           else
             echo "No changes to commit."

--- a/.github/workflows/update-stats.yml
+++ b/.github/workflows/update-stats.yml
@@ -84,7 +84,7 @@ jobs:
             git config user.name "github-actions[bot]"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git add public/stats.json
-            git commit -m "chore(stats): daily refresh [skip ci]"
+            git commit -m "chore(stats): daily refresh"
             git push
           else
             echo "No changes to commit."


### PR DESCRIPTION
## Summary
- remove `[skip ci]` from automated update commit messages so Pages deploy runs

## Testing
- `npm test` (fails: missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68bcb4e01b98832a8e97e376a64484c6