### PR TITLE
Show days since activity and include track artists

### DIFF
--- a/components/AutoScrollList.jsx
+++ b/components/AutoScrollList.jsx
@@ -2,7 +2,7 @@
 import React, { useEffect, useRef } from "react";
 
 export default function AutoScrollList({
-  items = [], // [{ id, title, subtitle, image, emoji, url }]
+  items = [], // [{ id, title, subtitle, image, emoji, url, info, trailing }]
   visibleCount = 5,
   speed = 10,
   resumeDelayMs = 2000,
@@ -183,7 +183,7 @@ export default function AutoScrollList({
                 key={`${item.id || item.title}-A-${i}`}
                 className="flex items-center justify-between gap-2"
               >
-                <div className="flex items-center gap-2 min-w-0">
+                <div className="flex items-center gap-2 min-w-0 flex-1">
                   {item.image ? (
                     <img src={item.image} alt="" className="w-8 h-8 rounded shrink-0" />
                   ) : item.emoji ? (
@@ -196,8 +196,8 @@ export default function AutoScrollList({
                       href={item.url}
                       target="_blank"
                       rel="noreferrer"
-                      className="text-sm truncate"
-                      title={`${item.title} — ${item.subtitle || ""}`}
+                      className="text-sm truncate flex-1 min-w-0"
+                      title={item.subtitle ? `${item.title} — ${item.subtitle}` : item.title}
                       onClick={(e) => e.stopPropagation()}
                     >
                       <span className="font-medium">{item.title}</span>
@@ -208,13 +208,21 @@ export default function AutoScrollList({
                       )}
                     </a>
                   ) : (
-                    <span className="text-sm truncate" title={`${item.title} — ${item.subtitle || ""}`}>
+                    <span
+                      className="text-sm truncate flex-1 min-w-0"
+                      title={item.subtitle ? `${item.title} — ${item.subtitle}` : item.title}
+                    >
                       <span className="font-medium">{item.title}</span>
                       {item.subtitle && (
                         <span className="text-slate-500 dark:text-slate-400">
                           {" "}– {item.subtitle}
                         </span>
                       )}
+                    </span>
+                  )}
+                  {item.info && (
+                    <span className="text-sm text-slate-500 dark:text-slate-400 shrink-0">
+                      {item.info}
                     </span>
                   )}
                 </div>
@@ -234,7 +242,7 @@ export default function AutoScrollList({
                 key={`${item.id || item.title}-B-${i}`}
                 className="flex items-center justify-between gap-2"
               >
-                <div className="flex items-center gap-2 min-w-0">
+                <div className="flex items-center gap-2 min-w-0 flex-1">
                   {item.image ? (
                     <img src={item.image} alt="" className="w-8 h-8 rounded shrink-0" />
                   ) : item.emoji ? (
@@ -247,8 +255,8 @@ export default function AutoScrollList({
                       href={item.url}
                       target="_blank"
                       rel="noreferrer"
-                      className="text-sm truncate"
-                      title={`${item.title} — ${item.subtitle || ""}`}
+                      className="text-sm truncate flex-1 min-w-0"
+                      title={item.subtitle ? `${item.title} — ${item.subtitle}` : item.title}
                       onClick={(e) => e.stopPropagation()}
                     >
                       <span className="font-medium">{item.title}</span>
@@ -259,13 +267,21 @@ export default function AutoScrollList({
                       )}
                     </a>
                   ) : (
-                    <span className="text-sm truncate" title={`${item.title} — ${item.subtitle || ""}`}>
+                    <span
+                      className="text-sm truncate flex-1 min-w-0"
+                      title={item.subtitle ? `${item.title} — ${item.subtitle}` : item.title}
+                    >
                       <span className="font-medium">{item.title}</span>
                       {item.subtitle && (
                         <span className="text-slate-500 dark:text-slate-400">
                           {" "}– {item.subtitle}
                         </span>
                       )}
+                    </span>
+                  )}
+                  {item.info && (
+                    <span className="text-sm text-slate-500 dark:text-slate-400 shrink-0">
+                      {item.info}
                     </span>
                   )}
                 </div>

--- a/components/AutoScrollList.jsx
+++ b/components/AutoScrollList.jsx
@@ -179,7 +179,10 @@ export default function AutoScrollList({
           {/* List A (measure & display) */}
           <ul ref={measureRef} className="space-y-2">
             {top10.map((item, i) => (
-              <li key={`${item.id || item.title}-A-${i}`} className="flex items-center justify-between gap-2">
+              <li
+                key={`${item.id || item.title}-A-${i}`}
+                className="flex items-center justify-between gap-2"
+              >
                 <div className="flex items-center gap-2 min-w-0">
                   {item.image ? (
                     <img src={item.image} alt="" className="w-8 h-8 rounded shrink-0" />
@@ -215,8 +218,10 @@ export default function AutoScrollList({
                     </span>
                   )}
                 </div>
-                <span className="text-sm text-slate-500 dark:text-slate-400 w-6 text-right shrink-0">
-                  #{i + 1}
+                <span
+                  className="text-sm text-slate-500 dark:text-slate-400 text-right shrink-0 w-12"
+                >
+                  {item.trailing || `#${i + 1}`}
                 </span>
               </li>
             ))}
@@ -225,7 +230,10 @@ export default function AutoScrollList({
           {/* List B (duplicate for seamless loop) */}
           <ul className="space-y-2">
             {top10.map((item, i) => (
-              <li key={`${item.id || item.title}-B-${i}`} className="flex items-center justify-between gap-2">
+              <li
+                key={`${item.id || item.title}-B-${i}`}
+                className="flex items-center justify-between gap-2"
+              >
                 <div className="flex items-center gap-2 min-w-0">
                   {item.image ? (
                     <img src={item.image} alt="" className="w-8 h-8 rounded shrink-0" />
@@ -261,8 +269,10 @@ export default function AutoScrollList({
                     </span>
                   )}
                 </div>
-                <span className="text-sm text-slate-500 dark:text-slate-400 w-6 text-right shrink-0">
-                  #{i + 1}
+                <span
+                  className="text-sm text-slate-500 dark:text-slate-400 text-right shrink-0 w-12"
+                >
+                  {item.trailing || `#${i + 1}`}
                 </span>
               </li>
             ))}

--- a/components/RecentActivities.jsx
+++ b/components/RecentActivities.jsx
@@ -17,10 +17,13 @@ export default function RecentActivities({ activities = [] }) {
     const start = new Date((a.start || "").replace(" ", "T"));
     const msPerDay = 1000 * 60 * 60 * 24;
     const daysAgo = Math.floor((Date.now() - start.getTime()) / msPerDay);
+    const distance = Math.round(Number(a.distance_km) || 0);
+    const duration = Number.isFinite(Number(a.duration_min)) ? Math.round(a.duration_min) : null;
     return {
       id: a.id,
       title: a.name || a.type || "Activity",
-      subtitle: `${a.distance_km} km in ${a.duration_min} min`,
+      subtitle: duration != null ? `${duration} min` : undefined,
+      info: `${distance} km`,
       url: a.id ? `https://connect.garmin.com/modern/activity/${a.id}` : undefined,
       emoji: typeEmoji[(a.type || "").toLowerCase()] || "🏃",
       trailing:

--- a/components/RecentActivities.jsx
+++ b/components/RecentActivities.jsx
@@ -13,13 +13,24 @@ const typeEmoji = {
 };
 
 export default function RecentActivities({ activities = [] }) {
-  const items = activities.slice(0, 10).map((a) => ({
-    id: a.id,
-    title: a.name || a.type || "Activity",
-    subtitle: `${a.start} • ${a.distance_km} km in ${a.duration_min} min`,
-    url: a.id ? `https://connect.garmin.com/modern/activity/${a.id}` : undefined,
-    emoji: typeEmoji[(a.type || "").toLowerCase()] || "🏃",
-  }));
+  const items = activities.slice(0, 10).map((a) => {
+    const start = new Date((a.start || "").replace(" ", "T"));
+    const msPerDay = 1000 * 60 * 60 * 24;
+    const daysAgo = Math.floor((Date.now() - start.getTime()) / msPerDay);
+    return {
+      id: a.id,
+      title: a.name || a.type || "Activity",
+      subtitle: `${a.distance_km} km in ${a.duration_min} min`,
+      url: a.id ? `https://connect.garmin.com/modern/activity/${a.id}` : undefined,
+      emoji: typeEmoji[(a.type || "").toLowerCase()] || "🏃",
+      trailing:
+        daysAgo <= 0
+          ? "today"
+          : daysAgo === 1
+          ? "1d ago"
+          : `${daysAgo}d ago`,
+    };
+  });
 
   return (
     <AutoScrollList

--- a/components/SpotifyTopTracks.jsx
+++ b/components/SpotifyTopTracks.jsx
@@ -4,8 +4,7 @@ import AutoScrollList from "@/components/AutoScrollList";
 export default function SpotifyTopTracks({ tracks = [], ...props }) {
   const items = tracks.slice(0, 10).map((t) => ({
     id: t.id,
-    title: t.name,
-    subtitle: t.artists,
+    title: `${t.name} – ${t.artists}`,
     image: t.image,
     url: t.url,
   }));


### PR DESCRIPTION
## Summary
- show how many days ago each Garmin activity occurred and drop the date in the subtitle
- allow AutoScrollList items to provide custom trailing text
- include the artist after each Spotify track title

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68bcc0352268832aa20f5f1718f94d92