### PR TITLE
Add visuals and emojis across portfolio

### DIFF
--- a/components/EducationItem.jsx
+++ b/components/EducationItem.jsx
@@ -1,15 +1,19 @@
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/Card';
 
 export default function EducationItem({ item }) {
+  const { school, degree, extras = [], img } = item;
   return (
     <Card>
       <CardHeader>
-        <CardTitle>{item.school}</CardTitle>
-        <div className="text-sm opacity-70">{item.degree}</div>
+        <div className="flex items-center gap-3">
+          {img && <img src={img} alt={`${school} logo`} className="w-8 h-8 object-contain" />}
+          <CardTitle>{school}</CardTitle>
+        </div>
+        <div className="text-sm opacity-70">{degree}</div>
       </CardHeader>
       <CardContent>
         <ul className="list-disc pl-5 space-y-2">
-          {item.extras.map((x, i) => (
+          {extras.map((x, i) => (
             <li key={i}>{x}</li>
           ))}
         </ul>

--- a/components/ExperienceItem.jsx
+++ b/components/ExperienceItem.jsx
@@ -1,12 +1,16 @@
 import { Card, CardHeader, CardTitle, CardContent } from "./ui/Card";
 
 export default function ExperienceItem({ job }) {
-  const { role, org, location, period, bullets = [] } = job;
+  const { role, org, location, period, bullets = [], img, emoji } = job;
   return (
     <Card>
       <CardHeader>
         <div className="flex items-center justify-between gap-4 flex-wrap">
-          <CardTitle>{role} — {org}</CardTitle>
+          <div className="flex items-center gap-3">
+            {img && <img src={img} alt={`${org} logo`} className="w-8 h-8 object-contain" />}
+            {!img && emoji && <span className="text-2xl">{emoji}</span>}
+            <CardTitle>{role} — {org}</CardTitle>
+          </div>
           <div className="text-sm opacity-70 flex items-center gap-3">
             <span>{location}</span><span>•</span><span>{period}</span>
           </div>

--- a/components/Hero.jsx
+++ b/components/Hero.jsx
@@ -1,4 +1,4 @@
-import { MapPin, Brain, FileText } from 'lucide-react';
+import { MapPin, Brain, FileText, Github, Linkedin } from 'lucide-react';
 import Badge from '@/components/ui/Badge';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/Card';
 import PillLink from '@/components/ui/PillLink';
@@ -23,16 +23,16 @@ export default function Hero({ links }) {
           </ul>
           <div className="flex flex-wrap gap-3 pt-2">
             <PillLink href="#projects" variant="solid" className="px-4">
-              See projects
+              📂 See projects
             </PillLink>
-            <PillLink href={links.github} external className="px-4">
+            <PillLink href={links.github} icon={Github} external className="px-4">
               GitHub
             </PillLink>
-            <PillLink href={links.linkedin} external className="px-4">
+            <PillLink href={links.linkedin} icon={Linkedin} external className="px-4">
               LinkedIn
             </PillLink>
             <PillLink href={links.email} variant="solid" className="px-4">
-              Contact
+              ✉️ Contact
             </PillLink>
           </div>
         </div>

--- a/components/ProjectCard.jsx
+++ b/components/ProjectCard.jsx
@@ -3,12 +3,12 @@ import { Card, CardHeader, CardTitle, CardContent } from './ui/Card';
 import PillLink from './ui/PillLink';
 
 export default function ProjectCard({ project }) {
-  const { title, period, stack = [], bullets = [], links = [] } = project;
+  const { title, period, stack = [], bullets = [], links = [], emoji } = project;
   return (
     <Card>
       <CardHeader>
         <div className="flex items-center justify-between gap-4 flex-wrap">
-          <CardTitle>{title}</CardTitle>
+          <CardTitle>{emoji ? `${emoji} ${title}` : title}</CardTitle>
           <span className="text-sm opacity-70">{period}</span>
         </div>
       </CardHeader>

--- a/components/RecentActivities.jsx
+++ b/components/RecentActivities.jsx
@@ -1,16 +1,12 @@
 // components/RecentActivities.jsx
 import AutoScrollList from "@/components/AutoScrollList";
 
-const typeEmoji = {
-  running: "🏃",
-  cycling: "🚴",
-  walking: "🚶",
-  swimming: "🏊",
-  hiking: "🥾",
-  rowing: "🚣",
-  skiing: "⛷️",
-  strength: "🏋️",
-};
+function activityEmoji(type = "") {
+  const t = type.toLowerCase();
+  if (t.includes("swim")) return "🏊";
+  if (t.includes("bike") || t.includes("cycl")) return "🚴";
+  return "🏃";
+}
 
 export default function RecentActivities({ activities = [] }) {
   const items = activities.slice(0, 10).map((a) => ({
@@ -18,7 +14,7 @@ export default function RecentActivities({ activities = [] }) {
     title: a.name || a.type || "Activity",
     subtitle: `${a.start} • ${a.distance_km} km in ${a.duration_min} min`,
     url: a.id ? `https://connect.garmin.com/modern/activity/${a.id}` : undefined,
-    emoji: typeEmoji[(a.type || "").toLowerCase()] || "🏃",
+    emoji: activityEmoji(a.type),
   }));
 
   return (

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -38,6 +38,7 @@ const education = [
   {
     school: 'Northeastern University — Khoury College of Computer Sciences',
     degree: 'B.S. in Computer Science & Mathematics (Expected May 2027)',
+    img: '/images/northeastern.svg',
     extras: [
       'GPA 3.64/4.0; Dean’s Scholarship; Dean’s List (Fall 2024, Spring 2025)',
       'Activities: Bridge to Calculus Tutor, Calculus Field Day Volunteer, Math Club, Putnam Club, Running Club',
@@ -47,6 +48,7 @@ const education = [
   {
     school: 'Corvinus University of Budapest - Mathematical Heritage of Budapest Summer Dialogue',
     degree: 'Budapest, Hungary (Jun – Aug 2025)',
+    img: '/images/corvinus.svg',
     extras: ['Courses: Number Theory, Exploration of Modern Mathematics'],
   },
 ];

--- a/public/experience.json
+++ b/public/experience.json
@@ -4,6 +4,7 @@
     "role": "Software Engineering Co-op",
     "location": "Boston, MA",
     "period": "Expected Sep. - Dec. 2025",
+    "img": "/images/northeastern.svg",
     "bullets": [
       "Building real-world software with peers in an agile, consulting-style team for Northeastern's industry partners.",
       "Taking full ownership of projects, from design to coding, testing, and client demonstrations.",
@@ -15,6 +16,7 @@
     "role": "Software Development Co-op",
     "location": "Groton, CT",
     "period": "Jan – Jul 2024",
+    "img": "/images/gdeb.svg",
     "bullets": [
       "Automated database accuracy via ServiceNow REST API; improved tracking of ~1000 assets.",
       "Automated XML transformation testing with Python/Batch; delivered digestible review outputs.",
@@ -26,6 +28,7 @@
     "role": "Administrative Assistant",
     "location": "Fort Meade, MD",
     "period": "Jun – Sep 2023",
+    "img": "/images/disa.svg",
     "bullets": [
       "Maintained records/databases to support mission accessibility.",
       "Obtained Secret security clearance after full background investigation.",

--- a/public/images/corvinus.svg
+++ b/public/images/corvinus.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="#003366"/>
+  <text x="50%" y="50%" dominant-baseline="central" text-anchor="middle" font-size="40" fill="#ffffff">CU</text>
+</svg>

--- a/public/images/disa.svg
+++ b/public/images/disa.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="#4b286d"/>
+  <text x="50%" y="50%" dominant-baseline="central" text-anchor="middle" font-size="40" fill="#ffffff">DISA</text>
+</svg>

--- a/public/images/gdeb.svg
+++ b/public/images/gdeb.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="#0033a0"/>
+  <text x="50%" y="50%" dominant-baseline="central" text-anchor="middle" font-size="40" fill="#ffffff">GD</text>
+</svg>

--- a/public/images/northeastern.svg
+++ b/public/images/northeastern.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="#cc0000"/>
+  <text x="50%" y="50%" dominant-baseline="central" text-anchor="middle" font-size="60" fill="#ffffff">N</text>
+</svg>

--- a/public/other-work.json
+++ b/public/other-work.json
@@ -4,6 +4,7 @@
     "role": "Semi-Professional Poker (NLHE)",
     "location": "Remote/Travel",
     "period": "May 2024 - Present",
+    "emoji": "🃏",
     "bullets": [
       "Applied probabilistic reasoning and risk management in competitive play.",
       "Tracked results and reviewed hands with peers to improve decision-making.",
@@ -15,6 +16,7 @@
     "role": "Computer Science Tutor (CSA)",
     "location": "Remote",
     "period": "Jul 2025 – Present",
+    "emoji": "👨‍🏫",
     "bullets": [
       "Mentoring on fundamentals and problem-solving patterns."
     ]

--- a/public/projects.json
+++ b/public/projects.json
@@ -1,6 +1,7 @@
 [
   {
     "title": "Human Digit Classification",
+    "emoji": "🔢",
     "period": "Jan – Mar 2025",
     "stack": ["Python","JavaScript","HTML","PyTorch","ML"],
     "bullets": [
@@ -12,6 +13,7 @@
   },
   {
     "title": "Counterfactual Regret Exploration (CFR-Min)",
+    "emoji": "♟️",
     "period": "Nov 2024 – Present",
     "stack": ["Jupyter","NumPy","Reinforcement Learning"],
     "bullets": [
@@ -23,6 +25,7 @@
   },
   {
     "title": "NLHE Alpha-Beta Pruning",
+    "emoji": "🃏",
     "period": "Aug – Dec 2024",
     "stack": ["Python","NumPy","Monte Carlo"],
     "bullets": [
@@ -34,6 +37,7 @@
   },
   {
     "title": "Linux Shell (C)",
+    "emoji": "🖥️",
     "period": "Oct 2024",
     "stack": ["C","Concurrency","Data Structures"],
     "bullets": [


### PR DESCRIPTION
## Summary
- show logos for experience and education entries
- decorate project and other work items with relevant emojis
- simplify Garmin activity emojis to runner, biker, or swimmer
- display GitHub and LinkedIn buttons with official logos instead of emojis

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68bcc1765e58832a9d454a6d70144c34