### PR TITLE
Limit weekly training graphs to last 8 weeks

### DIFF
--- a/public/stats.json
+++ b/public/stats.json
@@ -21,9 +21,9 @@
             "name": "Musculation",
             "type": "strength_training",
             "start": "2025-09-06 14:08:31",
-            "distance_km": 0.0,
+            "distance_km": 0,
             "duration_min": 44.9,
-            "avg_speed_kmh": 0.0
+            "avg_speed_kmh": 0
           },
           {
             "id": 20293900549,
@@ -48,9 +48,9 @@
             "name": "Vélo d'intérieur",
             "type": "indoor_cycling",
             "start": "2025-09-04 21:36:33",
-            "distance_km": 0.0,
+            "distance_km": 0,
             "duration_min": 14.5,
-            "avg_speed_kmh": 0.0
+            "avg_speed_kmh": 0
           },
           {
             "id": 20284176165,
@@ -66,81 +66,51 @@
             "name": "Vélo d'intérieur",
             "type": "indoor_cycling",
             "start": "2025-09-04 19:47:48",
-            "distance_km": 0.0,
+            "distance_km": 0,
             "duration_min": 23.2,
-            "avg_speed_kmh": 0.0
+            "avg_speed_kmh": 0
           },
           {
             "id": 20274025811,
             "name": "Vélo d'intérieur",
             "type": "indoor_cycling",
             "start": "2025-09-03 22:07:46",
-            "distance_km": 0.0,
-            "duration_min": 35.0,
-            "avg_speed_kmh": 0.0
+            "distance_km": 0,
+            "duration_min": 35,
+            "avg_speed_kmh": 0
           },
           {
             "id": 20266637938,
             "name": "Vélo d'intérieur",
             "type": "indoor_cycling",
             "start": "2025-09-03 07:32:46",
-            "distance_km": 0.0,
+            "distance_km": 0,
             "duration_min": 25.4,
-            "avg_speed_kmh": 0.0
+            "avg_speed_kmh": 0
           },
           {
             "id": 20261853685,
             "name": "Vélo d'intérieur",
             "type": "indoor_cycling",
             "start": "2025-09-02 17:50:03",
-            "distance_km": 0.0,
+            "distance_km": 0,
             "duration_min": 56.1,
-            "avg_speed_kmh": 0.0
+            "avg_speed_kmh": 0
           },
           {
             "id": 20255536596,
             "name": "Vélo d'intérieur",
             "type": "indoor_cycling",
             "start": "2025-09-02 07:04:44",
-            "distance_km": 0.0,
+            "distance_km": 0,
             "duration_min": 61.9,
-            "avg_speed_kmh": 0.0
+            "avg_speed_kmh": 0
           }
         ]
       },
       "weekly": {
-        "window_weeks": 12,
+        "window_weeks": 8,
         "series": [
-          {
-            "week_start": "2025-06-09",
-            "week_end": "2025-06-15",
-            "distance_km": 14.94,
-            "time_hours": 4.54
-          },
-          {
-            "week_start": "2025-06-16",
-            "week_end": "2025-06-22",
-            "distance_km": 20.66,
-            "time_hours": 5.91
-          },
-          {
-            "week_start": "2025-06-23",
-            "week_end": "2025-06-29",
-            "distance_km": 5.38,
-            "time_hours": 1.31
-          },
-          {
-            "week_start": "2025-06-30",
-            "week_end": "2025-07-06",
-            "distance_km": 31.13,
-            "time_hours": 3.27
-          },
-          {
-            "week_start": "2025-07-07",
-            "week_end": "2025-07-13",
-            "distance_km": 14.06,
-            "time_hours": 5.52
-          },
           {
             "week_start": "2025-07-14",
             "week_end": "2025-07-20",
@@ -225,124 +195,94 @@
             "name": "Vélo d'intérieur",
             "type": "indoor_cycling",
             "start": "2025-09-04 21:36:33",
-            "distance_km": 0.0,
+            "distance_km": 0,
             "duration_min": 14.5,
-            "avg_speed_kmh": 0.0
+            "avg_speed_kmh": 0
           },
           {
             "id": 20283842208,
             "name": "Vélo d'intérieur",
             "type": "indoor_cycling",
             "start": "2025-09-04 19:47:48",
-            "distance_km": 0.0,
+            "distance_km": 0,
             "duration_min": 23.2,
-            "avg_speed_kmh": 0.0
+            "avg_speed_kmh": 0
           },
           {
             "id": 20274025811,
             "name": "Vélo d'intérieur",
             "type": "indoor_cycling",
             "start": "2025-09-03 22:07:46",
-            "distance_km": 0.0,
-            "duration_min": 35.0,
-            "avg_speed_kmh": 0.0
+            "distance_km": 0,
+            "duration_min": 35,
+            "avg_speed_kmh": 0
           },
           {
             "id": 20266637938,
             "name": "Vélo d'intérieur",
             "type": "indoor_cycling",
             "start": "2025-09-03 07:32:46",
-            "distance_km": 0.0,
+            "distance_km": 0,
             "duration_min": 25.4,
-            "avg_speed_kmh": 0.0
+            "avg_speed_kmh": 0
           },
           {
             "id": 20261853685,
             "name": "Vélo d'intérieur",
             "type": "indoor_cycling",
             "start": "2025-09-02 17:50:03",
-            "distance_km": 0.0,
+            "distance_km": 0,
             "duration_min": 56.1,
-            "avg_speed_kmh": 0.0
+            "avg_speed_kmh": 0
           },
           {
             "id": 20255536596,
             "name": "Vélo d'intérieur",
             "type": "indoor_cycling",
             "start": "2025-09-02 07:04:44",
-            "distance_km": 0.0,
+            "distance_km": 0,
             "duration_min": 61.9,
-            "avg_speed_kmh": 0.0
+            "avg_speed_kmh": 0
           },
           {
             "id": 20254786033,
             "name": "Vélo d'intérieur",
             "type": "indoor_cycling",
             "start": "2025-09-01 17:42:59",
-            "distance_km": 0.0,
+            "distance_km": 0,
             "duration_min": 61.4,
-            "avg_speed_kmh": 0.0
+            "avg_speed_kmh": 0
           },
           {
             "id": 20254784986,
             "name": "Vélo d'intérieur",
             "type": "indoor_cycling",
             "start": "2025-09-01 09:02:36",
-            "distance_km": 0.0,
+            "distance_km": 0,
             "duration_min": 62.3,
-            "avg_speed_kmh": 0.0
+            "avg_speed_kmh": 0
           }
         ]
       },
       "weekly": {
-        "window_weeks": 12,
+        "window_weeks": 8,
         "series": [
-          {
-            "week_start": "2025-06-09",
-            "week_end": "2025-06-15",
-            "distance_km": 3.72,
-            "time_hours": 3.72
-          },
-          {
-            "week_start": "2025-06-16",
-            "week_end": "2025-06-22",
-            "distance_km": 7.58,
-            "time_hours": 3.28
-          },
-          {
-            "week_start": "2025-06-23",
-            "week_end": "2025-06-29",
-            "distance_km": 0.0,
-            "time_hours": 0.22
-          },
-          {
-            "week_start": "2025-06-30",
-            "week_end": "2025-07-06",
-            "distance_km": 0.0,
-            "time_hours": 0.59
-          },
-          {
-            "week_start": "2025-07-07",
-            "week_end": "2025-07-13",
-            "distance_km": 0.0,
-            "time_hours": 3.9
-          },
           {
             "week_start": "2025-07-14",
             "week_end": "2025-07-20",
-            "distance_km": 0.0,
+            "distance_km": 0,
             "time_hours": 3.51
           },
           {
             "week_start": "2025-07-21",
             "week_end": "2025-07-27",
-            "distance_km": 0.0,
+            "distance_km": 0,
             "time_hours": 5.23
           },
           {
             "week_start": "2025-07-28",
             "week_end": "2025-08-03",
-            "distance_km": 0.0,
+            "distance_km": 0,
             "time_hours": 0.6
           },
           {
@@ -481,38 +421,8 @@
         ]
       },
       "weekly": {
-        "window_weeks": 12,
+        "window_weeks": 8,
         "series": [
-          {
-            "week_start": "2025-06-09",
-            "week_end": "2025-06-15",
-            "distance_km": 11.21,
-            "time_hours": 0.82
-          },
-          {
-            "week_start": "2025-06-16",
-            "week_end": "2025-06-22",
-            "distance_km": 8.97,
-            "time_hours": 0.8
-          },
-          {
-            "week_start": "2025-06-23",
-            "week_end": "2025-06-29",
-            "distance_km": 3.78,
-            "time_hours": 0.29
-          },
-          {
-            "week_start": "2025-06-30",
-            "week_end": "2025-07-06",
-            "distance_km": 31.13,
-            "time_hours": 2.68
-          },
-          {
-            "week_start": "2025-07-07",
-            "week_end": "2025-07-13",
-            "distance_km": 13.7,
-            "time_hours": 1.09
-          },
           {
             "week_start": "2025-07-14",
             "week_end": "2025-07-20",
@@ -548,6 +458,12 @@
             "week_end": "2025-08-24",
             "distance_km": 16.64,
             "time_hours": 1.47
+          },
+          {
+            "week_start": "2025-08-25",
+            "week_end": "2025-08-31",
+            "distance_km": 0,
+            "time_hours": 0
           },
           {
             "week_start": "2025-09-01",
@@ -638,7 +554,7 @@
             "start": "2025-06-23 15:12:42",
             "distance_km": 1.6,
             "duration_min": 47.9,
-            "avg_speed_kmh": 2.0
+            "avg_speed_kmh": 2
           },
           {
             "id": 19525537393,
@@ -661,20 +577,8 @@
         ]
       },
       "weekly": {
-        "window_weeks": 12,
+        "window_weeks": 8,
         "series": [
-          {
-            "week_start": "2025-06-16",
-            "week_end": "2025-06-22",
-            "distance_km": 4.1,
-            "time_hours": 1.73
-          },
-          {
-            "week_start": "2025-06-23",
-            "week_end": "2025-06-29",
-            "distance_km": 1.6,
-            "time_hours": 0.8
-          },
           {
             "week_start": "2025-07-14",
             "week_end": "2025-07-20",
@@ -688,10 +592,40 @@
             "time_hours": 1.13
           },
           {
+            "week_start": "2025-07-28",
+            "week_end": "2025-08-03",
+            "distance_km": 0,
+            "time_hours": 0
+          },
+          {
             "week_start": "2025-08-04",
             "week_end": "2025-08-10",
             "distance_km": 3.61,
             "time_hours": 1.73
+          },
+          {
+            "week_start": "2025-08-11",
+            "week_end": "2025-08-17",
+            "distance_km": 0,
+            "time_hours": 0
+          },
+          {
+            "week_start": "2025-08-18",
+            "week_end": "2025-08-24",
+            "distance_km": 0,
+            "time_hours": 0
+          },
+          {
+            "week_start": "2025-08-25",
+            "week_end": "2025-08-31",
+            "distance_km": 0,
+            "time_hours": 0
+          },
+          {
+            "week_start": "2025-09-01",
+            "week_end": "2025-09-07",
+            "distance_km": 0,
+            "time_hours": 0
           }
         ]
       }

--- a/scripts/update_stats.py
+++ b/scripts/update_stats.py
@@ -35,7 +35,7 @@ TOKENS_DIR = Path(os.getenv("GARMIN_TOKENS_DIR", str(Path.home() / ".garminconne
 OUT_PATH = Path(os.getenv("GARMIN_OUT", "public/stats.json"))
 
 # How much history for weekly series (in weeks):
-WEEKLY_WINDOW = 12
+WEEKLY_WINDOW = 8
 # Monthly window for totals (in days):
 MONTHLY_WINDOW_DAYS = 30
 # How many recent activities to include:
@@ -237,9 +237,13 @@ def main() -> None:
             weekly[wk]["seconds"] += seconds(a)
 
         weekly_rows: List[Dict[str, Any]] = []
-        for wk in sorted(weekly.keys()):
-            m = weekly[wk]["meters"]
-            s = weekly[wk]["seconds"]
+        current_monday = today_dt - timedelta(days=today_dt.weekday())
+        start_week = current_monday - timedelta(weeks=WEEKLY_WINDOW - 1)
+        for i in range(WEEKLY_WINDOW):
+            wk_dt = start_week + timedelta(weeks=i)
+            wk = week_key(wk_dt)
+            m = weekly[wk]["meters"] if wk in weekly else 0.0
+            s = weekly[wk]["seconds"] if wk in weekly else 0.0
             weekly_rows.append({
                 "week_start": wk[0],
                 "week_end": wk[1],


### PR DESCRIPTION
## Summary
- Restrict weekly stats to an 8-week window
- Fill missing weeks with zero distance and time
- Update sample stats to include 8 weeks of data

## Testing
- `python -m py_compile scripts/update_stats.py`
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68bcfbb2a7b0832a89e6cf0a53b9c071