### PR TITLE
Standardize button styling

### DIFF
--- a/components/Header.jsx
+++ b/components/Header.jsx
@@ -13,7 +13,7 @@ export default function Header({ links }) {
               key={id}
               href={`#${id}`}
               variant="solid"
-              className="capitalize hover:bg-slate-100 dark:hover:bg-slate-800"
+              className="capitalize"
             >
               {id}
             </PillLink>

--- a/components/ThemeToggle.jsx
+++ b/components/ThemeToggle.jsx
@@ -6,7 +6,7 @@ export default function ThemeToggle() {
   if (!mounted) return null;
   return (
     <button onClick={toggle} aria-label="Toggle theme"
-      className="pill-outline flex items-center gap-2">
+      className="pill-accent">
       {dark ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
       <span className="hidden sm:inline">{dark ? "Light" : "Dark"}</span>
     </button>

--- a/components/ui/PillLink.jsx
+++ b/components/ui/PillLink.jsx
@@ -1,9 +1,10 @@
 export default function PillLink({ href, children, icon: Icon, variant = 'outline', external = false, className = '' }) {
-  const base =
-    variant === 'solid'
-      ? 'pill bg-slate-900 text-white dark:bg-white dark:text-slate-900'
-      : 'pill-outline';
-  const classes = `${base} flex items-center gap-2 ${className}`.trim();
+  const variantClass =
+    ({
+      solid: 'pill-accent',
+      outline: 'pill-accent',
+    }[variant]) ?? 'pill-accent';
+  const classes = `${variantClass} ${className}`.trim();
   return (
     <a
       href={href}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -15,7 +15,13 @@ body { @apply bg-gradient-to-b from-white to-slate-50 text-slate-900; }
 .card { box-shadow: 0 1px 3px rgba(0,0,0,.08), 0 1px 2px rgba(0,0,0,.06); }
 .badge { @apply inline-flex items-center px-3 py-1 rounded-full text-sm bg-slate-100; }
 .pill { @apply px-3 py-2 rounded-full; }
-.pill-outline { @apply pill border hover:bg-white dark:hover:bg-slate-800; }
+.pill-accent {
+  @apply pill inline-flex items-center gap-2 font-medium border border-transparent shadow-sm transition-colors;
+  @apply bg-slate-900 text-white hover:bg-slate-700;
+  @apply dark:bg-white dark:text-slate-900 dark:hover:bg-slate-200;
+  @apply focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-400;
+  @apply dark:focus-visible:outline-white/70;
+}
 .section-container { @apply max-w-5xl mx-auto px-4 sm:px-6 lg:px-8; }
 
 /* Hide scrollbars but allow scrolling */


### PR DESCRIPTION
## Summary
- add a shared `pill-accent` style to keep all pill buttons the same color in light and dark themes
- update `PillLink` and the theme toggle to use the shared accent styling and remove conflicting hover overrides

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68cc62db7674832aaa9be18c35c0201e