### PR TITLE
Implement stacked hover sections

### DIFF
--- a/components/SkillCategoryCard.jsx
+++ b/components/SkillCategoryCard.jsx
@@ -1,0 +1,21 @@
+import Badge from '@/components/ui/Badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
+
+export default function SkillCategoryCard({ category }) {
+  const { title, items = [] } = category;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="flex flex-wrap gap-2">
+          {items.map(item => (
+            <Badge key={item}>{item}</Badge>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/StackedCardSection.jsx
+++ b/components/StackedCardSection.jsx
@@ -1,0 +1,104 @@
+import { useEffect, useState } from 'react';
+
+export default function StackedCardSection({
+  id,
+  title,
+  icon: Icon,
+  items = [],
+  renderItem,
+  getKey = (_, index) => index,
+  stackOffset = 32,
+  className = '',
+  contentClassName = '',
+}) {
+  const [hoveredIndex, setHoveredIndex] = useState(null);
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const handleChange = event => setPrefersReducedMotion(event.matches);
+
+    // Initialize state on mount
+    setPrefersReducedMotion(mediaQuery.matches);
+
+    if (mediaQuery.addEventListener) {
+      mediaQuery.addEventListener('change', handleChange);
+    } else if (mediaQuery.addListener) {
+      mediaQuery.addListener(handleChange);
+    }
+
+    return () => {
+      if (mediaQuery.removeEventListener) {
+        mediaQuery.removeEventListener('change', handleChange);
+      } else if (mediaQuery.removeListener) {
+        mediaQuery.removeListener(handleChange);
+      }
+    };
+  }, []);
+
+  const handleFocus = index => {
+    setHoveredIndex(index);
+  };
+
+  const handleBlur = event => {
+    const { currentTarget, relatedTarget } = event;
+    if (!currentTarget.contains(relatedTarget)) {
+      setHoveredIndex(null);
+    }
+  };
+
+  const handleLeave = () => {
+    setHoveredIndex(null);
+  };
+
+  return (
+    <section
+      id={id}
+      className={`flex h-full flex-col py-10 scroll-mt-16 ${className}`.trim()}
+      onMouseLeave={handleLeave}
+    >
+      <div className="mb-6 flex items-center gap-3">
+        {Icon && (
+          <div className="card rounded-xl border bg-white p-2 dark:bg-slate-900">
+            <Icon className="h-5 w-5" />
+          </div>
+        )}
+        <h2 className="text-2xl font-semibold">{title}</h2>
+      </div>
+
+      <div className={`relative flex flex-col ${contentClassName}`.trim()}>
+        {items.map((item, index) => {
+          const isHovered = hoveredIndex === index;
+          const translateY = isHovered ? 0 : -index * stackOffset;
+          const transition = prefersReducedMotion ? '0s' : '300ms';
+
+          return (
+            <div
+              key={getKey(item, index)}
+              tabIndex={0}
+              onFocus={() => handleFocus(index)}
+              onBlur={handleBlur}
+              onMouseEnter={() => handleFocus(index)}
+              className={`relative ${index !== 0 ? 'mt-6' : ''} rounded-2xl transition-transform transition-[filter] duration-300 ease-out focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/80 focus-visible:ring-offset-2 focus-visible:ring-offset-white focus-visible:ring-opacity-70 dark:focus-visible:ring-offset-slate-950`}
+              style={{
+                transform: `translateY(${translateY}px)`,
+                transitionDuration: transition,
+                zIndex: isHovered ? items.length + 10 : items.length - index,
+                filter:
+                  hoveredIndex !== null && hoveredIndex !== index
+                    ? 'brightness(0.92)'
+                    : 'none',
+              }}
+            >
+              {renderItem(item, index, isHovered)}
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -9,12 +9,11 @@ import Header from '@/components/Header';
 import Hero from '@/components/Hero';
 import AboutSection from '@/components/AboutSection';
 import Footer from '@/components/Footer';
-import ListSection from '@/components/ListSection';
-import Section from '@/components/ui/Section';
 import ProjectCard from '@/components/ProjectCard';
 import ExperienceItem from '@/components/ExperienceItem';
 import EducationItem from '@/components/EducationItem';
-import SkillsGrid from '@/components/SkillsGrid';
+import StackedCardSection from '@/components/StackedCardSection';
+import SkillCategoryCard from '@/components/SkillCategoryCard';
 import { Trophy, Briefcase, GraduationCap, Cpu, ClipboardList } from 'lucide-react';
 
 const projects = validateProjects(rawProjects) ? rawProjects : [];
@@ -57,6 +56,12 @@ const interests = [
   'Brain Teasers', 'Game Theory', 'Poker', 'Chess', 'Français', 'Track & Field', 'Triathlon', 'Skiing', 'Sports Science'
 ];
 
+const skillCategories = [
+  { title: 'Languages', items: skills.languages },
+  { title: 'Tools & Libraries', items: skills.tools },
+  { title: 'Platforms', items: skills.platforms },
+];
+
 export default function Home() {
   return (
     <>
@@ -76,42 +81,59 @@ export default function Home() {
       <Hero links={links} />
       <AboutSection interests={interests} />
 
-      <ListSection
-        id="experience"
-        title="Experience"
-        icon={Briefcase}
-        items={experience}
-        renderItem={job => <ExperienceItem key={job.org} job={job} />}
-      />
+      <div className="section-container">
+        <div className="grid gap-12 lg:grid-cols-2">
+          <StackedCardSection
+            id="experience"
+            title="Experience"
+            icon={Briefcase}
+            items={experience}
+            getKey={job => `${job.org}-${job.role}`}
+            renderItem={job => <ExperienceItem job={job} />}
+          />
+          <StackedCardSection
+            id="projects"
+            title="Projects"
+            icon={Trophy}
+            items={projects}
+            getKey={project => project.title}
+            renderItem={project => <ProjectCard project={project} />}
+          />
+        </div>
+      </div>
 
-      <ListSection
-        id="other-work"
-        title="Other Work"
-        icon={ClipboardList}
-        items={otherWork}
-        renderItem={job => <ExperienceItem key={job.org} job={job} />}
-      />
+      <div className="section-container">
+        <div className="grid gap-12 lg:grid-cols-2">
+          <StackedCardSection
+            id="education"
+            title="Education"
+            icon={GraduationCap}
+            items={education}
+            getKey={item => item.school}
+            renderItem={item => <EducationItem item={item} />}
+          />
+          <StackedCardSection
+            id="other-work"
+            title="Other Work"
+            icon={ClipboardList}
+            items={otherWork}
+            getKey={job => `${job.org}-${job.role}`}
+            renderItem={job => <ExperienceItem job={job} />}
+          />
+        </div>
+      </div>
 
-      <ListSection
-        id="projects"
-        title="Projects"
-        icon={Trophy}
-        items={projects}
-        columns={2}
-        renderItem={p => <ProjectCard key={p.title} project={p} />}
-      />
-
-      <ListSection
-        id="education"
-        title="Education"
-        icon={GraduationCap}
-        items={education}
-        renderItem={e => <EducationItem key={e.school} item={e} />}
-      />
-
-      <Section id="skills" title="Skills" icon={Cpu}>
-        <SkillsGrid skills={skills} />
-      </Section>
+      <div className="section-container">
+        <StackedCardSection
+          id="skills"
+          title="Skills"
+          icon={Cpu}
+          items={skillCategories}
+          getKey={category => category.title}
+          stackOffset={24}
+          renderItem={category => <SkillCategoryCard category={category} />}
+        />
+      </div>
 
       <Footer links={links} />
     </>


### PR DESCRIPTION
## Summary
- add a reusable stacked card section component with hover isolation behavior and reduced-motion support
- create a skill category card for rendering grouped badges
- restructure the home page to use the stacked sections for experience, projects, education, other work, and skills, placing the sections in a responsive two-row layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68cc64c3c760832ab35e61181096904d