### PR TITLE
Overhaul stacked section interactions

### DIFF
--- a/components/EducationItem.jsx
+++ b/components/EducationItem.jsx
@@ -1,23 +1,35 @@
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/Card';
 
-export default function EducationItem({ item }) {
+export default function EducationItem({ item, compact = false }) {
   const { school, degree, extras = [], img } = item;
+  const firstExtra = extras[0];
+
   return (
-    <Card>
-      <CardHeader>
+    <Card className={compact ? 'shadow-sm' : ''}>
+      <CardHeader className={compact ? 'pb-3' : ''}>
         <div className="flex items-center gap-3">
           {img && <img src={img} alt={`${school} logo`} className="w-8 h-8 object-contain" />}
-          <CardTitle>{school}</CardTitle>
+          <CardTitle className={compact ? 'text-base font-semibold' : ''}>{school}</CardTitle>
         </div>
-        <div className="text-sm opacity-70">{degree}</div>
+        <div className={compact ? 'text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400' : 'text-sm opacity-70'}>
+          {degree}
+        </div>
       </CardHeader>
-      <CardContent>
-        <ul className="list-disc pl-5 space-y-2">
-          {extras.map((x, i) => (
-            <li key={i}>{x}</li>
-          ))}
-        </ul>
-      </CardContent>
+      {compact ? (
+        firstExtra ? (
+          <CardContent className="px-6 pb-4 pt-0 text-sm text-slate-600 dark:text-slate-300">
+            <p className="truncate">{firstExtra}</p>
+          </CardContent>
+        ) : null
+      ) : (
+        <CardContent>
+          <ul className="list-disc pl-5 space-y-2">
+            {extras.map((x, i) => (
+              <li key={i}>{x}</li>
+            ))}
+          </ul>
+        </CardContent>
+      )}
     </Card>
   );
 }

--- a/components/ExperienceItem.jsx
+++ b/components/ExperienceItem.jsx
@@ -1,26 +1,50 @@
 import { Card, CardHeader, CardTitle, CardContent } from "./ui/Card";
 
-export default function ExperienceItem({ job }) {
+export default function ExperienceItem({ job, compact = false }) {
   const { role, org, location, period, bullets = [], img, emoji } = job;
+  const locationPeriod = [location, period].filter(Boolean);
+  const firstBullet = bullets[0];
+
   return (
-    <Card>
-      <CardHeader>
-        <div className="flex items-center justify-between gap-4 flex-wrap">
+    <Card className={compact ? 'shadow-sm' : ''}>
+      <CardHeader className={compact ? 'pb-3' : ''}>
+        <div className={`flex items-center justify-between gap-4 ${compact ? 'flex-nowrap' : 'flex-wrap'}`}>
           <div className="flex items-center gap-3">
             {img && <img src={img} alt={`${org} logo`} className="w-8 h-8 object-contain" />}
             {!img && emoji && <span className="text-2xl">{emoji}</span>}
-            <CardTitle>{role} — {org}</CardTitle>
+            <CardTitle className={compact ? 'text-base font-semibold' : ''}>
+              {role} — {org}
+            </CardTitle>
           </div>
-          <div className="text-sm opacity-70 flex items-center gap-3">
-            <span>{location}</span><span>•</span><span>{period}</span>
-          </div>
+          {!compact && (
+            <div className="text-sm opacity-70 flex items-center gap-3">
+              {location && <span>{location}</span>}
+              {location && period && <span>•</span>}
+              {period && <span>{period}</span>}
+            </div>
+          )}
         </div>
+        {compact && locationPeriod.length > 0 && (
+          <div className="mt-2 text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400 flex items-center gap-2">
+            {location && <span>{location}</span>}
+            {location && period && <span>•</span>}
+            {period && <span>{period}</span>}
+          </div>
+        )}
       </CardHeader>
-      <CardContent>
-        <ul className="list-disc pl-5 space-y-2">
-          {bullets.map((b, i) => <li key={i}>{b}</li>)}
-        </ul>
-      </CardContent>
+      {compact ? (
+        firstBullet ? (
+          <CardContent className="px-6 pb-4 pt-0 text-sm text-slate-600 dark:text-slate-300">
+            <p className="truncate">{firstBullet}</p>
+          </CardContent>
+        ) : null
+      ) : (
+        <CardContent>
+          <ul className="list-disc pl-5 space-y-2">
+            {bullets.map((b, i) => <li key={i}>{b}</li>)}
+          </ul>
+        </CardContent>
+      )}
     </Card>
   );
 }

--- a/components/ProjectCard.jsx
+++ b/components/ProjectCard.jsx
@@ -2,37 +2,65 @@ import Badge from './ui/Badge';
 import { Card, CardHeader, CardTitle, CardContent } from './ui/Card';
 import PillLink from './ui/PillLink';
 
-export default function ProjectCard({ project }) {
+export default function ProjectCard({ project, compact = false }) {
   const { title, period, stack = [], bullets = [], links = [], emoji } = project;
+  const previewStack = stack.slice(0, 3);
+  const stackOverflow = stack.length - previewStack.length;
+  const firstBullet = bullets[0];
+  const primaryLink = links[0];
+
   return (
-    <Card>
-      <CardHeader>
+    <Card className={compact ? 'shadow-sm' : ''}>
+      <CardHeader className={compact ? 'pb-3' : ''}>
         <div className="flex items-center justify-between gap-4 flex-wrap">
-          <CardTitle>{emoji ? `${emoji} ${title}` : title}</CardTitle>
-          <span className="text-sm opacity-70">{period}</span>
+          <CardTitle className={compact ? 'text-base font-semibold' : ''}>
+            {emoji ? `${emoji} ${title}` : title}
+          </CardTitle>
+          <span className={compact ? 'text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400' : 'text-sm opacity-70'}>
+            {period}
+          </span>
         </div>
-      </CardHeader>
-      <CardContent>
-        {!!stack.length && (
-          <div className="flex flex-wrap gap-2">
-            {stack.map((s) => <Badge key={s}>{s}</Badge>)}
-          </div>
-        )}
-        {!!bullets.length && (
-          <ul className="list-disc pl-5 space-y-2">
-            {bullets.map((b, i) => <li key={i}>{b}</li>)}
-          </ul>
-        )}
-        {!!links.length && (
-          <div className="flex flex-wrap gap-3 pt-1">
-            {links.map((l, i) => (
-              <PillLink key={i} href={l.href} external>
-                {l.label}
-              </PillLink>
+        {compact && previewStack.length > 0 && (
+          <div className="mt-2 text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400 flex flex-wrap gap-2">
+            {previewStack.map((s) => (
+              <span key={s}>{s}</span>
             ))}
+            {stackOverflow > 0 && <span>+{stackOverflow}</span>}
           </div>
         )}
-      </CardContent>
+      </CardHeader>
+      {compact ? (
+        <CardContent className="px-6 pb-4 pt-0 text-sm text-slate-600 dark:text-slate-300 space-y-2">
+          {firstBullet && <p className="truncate">{firstBullet}</p>}
+          {primaryLink && (
+            <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+              {primaryLink.label}
+            </p>
+          )}
+        </CardContent>
+      ) : (
+        <CardContent>
+          {!!stack.length && (
+            <div className="flex flex-wrap gap-2">
+              {stack.map((s) => <Badge key={s}>{s}</Badge>)}
+            </div>
+          )}
+          {!!bullets.length && (
+            <ul className="list-disc pl-5 space-y-2">
+              {bullets.map((b, i) => <li key={i}>{b}</li>)}
+            </ul>
+          )}
+          {!!links.length && (
+            <div className="flex flex-wrap gap-3 pt-1">
+              {links.map((l, i) => (
+                <PillLink key={i} href={l.href} external>
+                  {l.label}
+                </PillLink>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      )}
     </Card>
   );
 }

--- a/components/StackedCardSection.jsx
+++ b/components/StackedCardSection.jsx
@@ -1,0 +1,192 @@
+import { useState } from 'react';
+import Section from '@/components/ui/Section';
+
+const DEFAULT_STACK_OFFSET = 120; // px
+const DEFAULT_BASE_GAP = 20;
+const DEFAULT_FLOAT_OFFSET = 6;
+
+export default function StackedCardSection({
+  id,
+  title,
+  icon,
+  items = [],
+  renderItem,
+  keyExtractor,
+  className = '',
+  stackOffset = DEFAULT_STACK_OFFSET,
+  baseGap = DEFAULT_BASE_GAP,
+  floatOffset = DEFAULT_FLOAT_OFFSET,
+  expandOnHover = false,
+  activeSectionId = null,
+  setActiveSectionId,
+}) {
+  const [hoveredIndex, setHoveredIndex] = useState(null);
+  const shouldStack = items.length > 1;
+  const collapsedMargin = shouldStack ? baseGap - stackOffset : baseGap;
+  const isInteractive = expandOnHover && typeof setActiveSectionId === 'function';
+  const isActive = isInteractive && activeSectionId === id;
+  const isDimmed = isInteractive && activeSectionId && activeSectionId !== id;
+  const sectionClassName = [
+    'h-full transition-all duration-300 ease-out',
+    isInteractive ? 'relative overflow-visible' : '',
+    isActive ? 'md:col-span-2 lg:col-span-2 xl:col-span-2 z-30' : '',
+    isDimmed ? 'opacity-0 pointer-events-none scale-95' : '',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  const handleSectionLeave = () => {
+    if (isInteractive) {
+      setActiveSectionId(null);
+    } else {
+      setHoveredIndex(null);
+    }
+  };
+
+  const handleFocusOut = (event) => {
+    if (!event.currentTarget.contains(event.relatedTarget)) {
+      if (isInteractive) {
+        setActiveSectionId(null);
+      } else {
+        setHoveredIndex(null);
+      }
+    }
+  };
+
+  const handleKeyDown = (event) => {
+    if (event.key === 'Escape' && isInteractive) {
+      setActiveSectionId(null);
+    }
+  };
+
+  const renderPreviewStack = () => (
+    <div
+      className={[
+        'relative flex flex-col transition-[opacity,transform] duration-300 ease-out',
+        isActive ? 'absolute inset-0 opacity-0 -translate-y-3 pointer-events-none' : 'opacity-100 translate-y-0',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      aria-hidden={isActive}
+    >
+      {items.map((item, index) => {
+        const key = keyExtractor ? keyExtractor(item, index) : index;
+        const translateY = shouldStack ? -floatOffset * index : 0;
+        const style = {
+          marginTop: index === 0 ? 0 : collapsedMargin,
+          transform: `translateY(${translateY}px) scale(0.96)`,
+          transformOrigin: 'top center',
+          zIndex: items.length - index,
+        };
+
+        return (
+          <div
+            key={key}
+            className="relative transition-all duration-300 ease-out"
+            style={style}
+          >
+            <div className="pointer-events-none select-none">
+              {renderItem(item, index, { mode: 'preview', isActive })}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+
+  const renderExpandedGrid = () => (
+    <div
+      className={[
+        'absolute inset-0 transition-all duration-300 ease-out',
+        isActive ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-3 pointer-events-none',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      aria-hidden={!isActive}
+    >
+      <div className="relative w-full h-full">
+        <div className="absolute inset-0 -m-1">
+          <div className="h-full w-full max-h-[70vh] overflow-y-auto rounded-3xl border border-slate-200/60 bg-white/95 p-6 shadow-2xl dark:border-slate-800/60 dark:bg-slate-950/85">
+            <div className="grid gap-6 sm:grid-cols-2 xl:grid-cols-3">
+              {items.map((item, index) => {
+                const key = keyExtractor ? keyExtractor(item, index) : index;
+                return (
+                  <div key={key} className="h-full">
+                    {renderItem(item, index, { mode: 'expanded', isActive })}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+
+  if (isInteractive) {
+    return (
+      <Section id={id} title={title} icon={icon} className={sectionClassName}>
+        <div
+          className="relative min-h-[240px] sm:min-h-[260px]"
+          onMouseEnter={() => setActiveSectionId(id)}
+          onMouseLeave={handleSectionLeave}
+          onFocusCapture={() => setActiveSectionId(id)}
+          onBlurCapture={handleFocusOut}
+          onKeyDown={handleKeyDown}
+          tabIndex={0}
+        >
+          {renderPreviewStack()}
+          {renderExpandedGrid()}
+        </div>
+      </Section>
+    );
+  }
+
+  return (
+    <Section id={id} title={title} icon={icon} className={sectionClassName}>
+      <div
+        className="relative flex flex-col"
+        onMouseLeave={handleSectionLeave}
+      >
+        {items.map((item, index) => {
+          const key = keyExtractor ? keyExtractor(item, index) : index;
+          const isHovered = hoveredIndex === index;
+          const translateY = shouldStack ? (isHovered ? 0 : -floatOffset * index) : 0;
+          const marginTop = index === 0 ? 0 : isHovered ? baseGap : collapsedMargin;
+          const style = {
+            marginTop,
+            transform: `translateY(${translateY}px)`,
+            zIndex: isHovered ? items.length + 5 : items.length - index,
+          };
+          const dimOpacity = hoveredIndex !== null && !isHovered ? 0.6 : 1;
+          const scaleClass =
+            hoveredIndex === null
+              ? 'scale-100'
+              : isHovered
+                ? 'scale-[1.015]'
+                : 'scale-[0.99]';
+          const emphasisClass = isHovered ? 'drop-shadow-xl' : '';
+
+          return (
+            <div
+              key={key}
+              className="relative transition-all duration-300 ease-out"
+              style={style}
+              onMouseEnter={() => setHoveredIndex(index)}
+              onFocusCapture={() => setHoveredIndex(index)}
+              onBlurCapture={handleFocusOut}
+            >
+              <div
+                className={`transition-all duration-300 transform origin-top ${scaleClass} ${emphasisClass}`.trim()}
+                style={{ opacity: dimOpacity }}
+              >
+                {renderItem(item, index, { mode: 'stacked', isHovered })}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </Section>
+  );
+}

--- a/components/ui/Section.jsx
+++ b/components/ui/Section.jsx
@@ -1,18 +1,17 @@
-export default function Section({ id, title, icon, children }) {
-    const Icon = icon;
-    return (
-        <section
-           id={id}
-            className="section-container py-10 scroll-mt-16"
-        >
-	<div className="flex items-center gap-3 mb-6">
-	<div className="p-2 rounded-xl border bg-white dark:bg-slate-900 card">
-	<Icon className="w-5 h-5" />
-	</div>
-	<h2 className="text-2xl font-semibold">{title}</h2>
-	</div>
-	{children}
-	</section>
-    );
+export default function Section({ id, title, icon, children, className = '' }) {
+  const Icon = icon;
+  const sectionClassName = `section-container py-10 scroll-mt-16 ${className}`.trim();
+
+  return (
+    <section id={id} className={sectionClassName}>
+      <div className="flex items-center gap-3 mb-6">
+        <div className="p-2 rounded-xl border bg-white dark:bg-slate-900 card">
+          <Icon className="w-5 h-5" />
+        </div>
+        <h2 className="text-2xl font-semibold">{title}</h2>
+      </div>
+      {children}
+    </section>
+  );
 }
 

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import Head from 'next/head';
 import rawProjects from '@/public/projects.json' assert { type: 'json' };
 import rawExperience from '@/public/experience.json' assert { type: 'json' };
@@ -9,12 +10,12 @@ import Header from '@/components/Header';
 import Hero from '@/components/Hero';
 import AboutSection from '@/components/AboutSection';
 import Footer from '@/components/Footer';
-import ListSection from '@/components/ListSection';
-import Section from '@/components/ui/Section';
+import StackedCardSection from '@/components/StackedCardSection';
 import ProjectCard from '@/components/ProjectCard';
 import ExperienceItem from '@/components/ExperienceItem';
 import EducationItem from '@/components/EducationItem';
-import SkillsGrid from '@/components/SkillsGrid';
+import Badge from '@/components/ui/Badge';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/Card';
 import { Trophy, Briefcase, GraduationCap, Cpu, ClipboardList } from 'lucide-react';
 
 const projects = validateProjects(rawProjects) ? rawProjects : [];
@@ -33,6 +34,12 @@ const skills = {
   tools: ['Git', 'PyTorch', 'NumPy', 'Neovim', 'Matplotlib', 'Jupyter', 'React'],
   platforms: ['Windows', 'macOS', 'Ubuntu Linux'],
 };
+
+const skillCategories = [
+  { title: 'Languages', items: skills.languages },
+  { title: 'Tools & Libraries', items: skills.tools },
+  { title: 'Platforms', items: skills.platforms },
+];
 
 const education = [
   {
@@ -58,6 +65,8 @@ const interests = [
 ];
 
 export default function Home() {
+  const [activeStackSection, setActiveStackSection] = useState(null);
+
   return (
     <>
       <Head>
@@ -76,42 +85,109 @@ export default function Home() {
       <Hero links={links} />
       <AboutSection interests={interests} />
 
-      <ListSection
-        id="experience"
-        title="Experience"
-        icon={Briefcase}
-        items={experience}
-        renderItem={job => <ExperienceItem key={job.org} job={job} />}
-      />
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 space-y-8">
+        <div className="relative">
+          {activeStackSection && (
+            <div className="pointer-events-none absolute -inset-4 rounded-[32px] bg-slate-950/60 backdrop-blur-sm transition-opacity duration-300 z-10" />
+          )}
+          <div className={`space-y-8 relative ${activeStackSection ? 'z-20' : ''}`}>
+            <div className="grid gap-8 md:grid-cols-2">
+              <StackedCardSection
+                id="experience"
+                title="Experience"
+                icon={Briefcase}
+                items={experience}
+                keyExtractor={job => job.org}
+                renderItem={(job, _, context) => (
+                  <ExperienceItem job={job} compact={context?.mode === 'preview'} />
+                )}
+                className="px-0 md:mx-0 py-6 md:py-8"
+                stackOffset={168}
+                expandOnHover
+                activeSectionId={activeStackSection}
+                setActiveSectionId={setActiveStackSection}
+              />
+              <StackedCardSection
+                id="projects"
+                title="Projects"
+                icon={Trophy}
+                items={projects}
+                keyExtractor={project => project.title}
+                renderItem={(project, _, context) => (
+                  <ProjectCard project={project} compact={context?.mode === 'preview'} />
+                )}
+                className="px-0 md:mx-0 py-6 md:py-8"
+                stackOffset={168}
+                expandOnHover
+                activeSectionId={activeStackSection}
+                setActiveSectionId={setActiveStackSection}
+              />
+            </div>
+            <div className="grid gap-8 md:grid-cols-2">
+              <StackedCardSection
+                id="education"
+                title="Education"
+                icon={GraduationCap}
+                items={education}
+                keyExtractor={item => item.school}
+                renderItem={(item, _, context) => (
+                  <EducationItem item={item} compact={context?.mode === 'preview'} />
+                )}
+                className="px-0 md:mx-0 py-6 md:py-8"
+                stackOffset={168}
+                expandOnHover
+                activeSectionId={activeStackSection}
+                setActiveSectionId={setActiveStackSection}
+              />
+              <StackedCardSection
+                id="other-work"
+                title="Other Work"
+                icon={ClipboardList}
+                items={otherWork}
+                keyExtractor={job => job.org}
+                renderItem={(job, _, context) => (
+                  <ExperienceItem job={job} compact={context?.mode === 'preview'} />
+                )}
+                className="px-0 md:mx-0 py-6 md:py-8"
+                stackOffset={168}
+                expandOnHover
+                activeSectionId={activeStackSection}
+                setActiveSectionId={setActiveStackSection}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
 
-      <ListSection
-        id="other-work"
-        title="Other Work"
-        icon={ClipboardList}
-        items={otherWork}
-        renderItem={job => <ExperienceItem key={job.org} job={job} />}
-      />
+      <StackedCardSection
+        id="skills"
+        title="Skills"
+        icon={Cpu}
+        items={skillCategories}
+        keyExtractor={category => category.title}
+        renderItem={(category, _, context) => {
+          const isPreview = context?.mode === 'preview';
+          const items = isPreview ? category.items.slice(0, 6) : category.items;
 
-      <ListSection
-        id="projects"
-        title="Projects"
-        icon={Trophy}
-        items={projects}
-        columns={2}
-        renderItem={p => <ProjectCard key={p.title} project={p} />}
+          return (
+            <Card className={isPreview ? 'shadow-sm' : ''}>
+              <CardHeader className={isPreview ? 'pb-3' : ''}>
+                <CardTitle className={isPreview ? 'text-base font-semibold' : ''}>{category.title}</CardTitle>
+              </CardHeader>
+              <CardContent className={isPreview ? 'px-6 pb-4 pt-0' : ''}>
+                <div className="flex flex-wrap gap-2">
+                  {items.map(item => (
+                    <Badge key={item}>{item}</Badge>
+                  ))}
+                  {isPreview && category.items.length > items.length && (
+                    <Badge key="more">+{category.items.length - items.length}</Badge>
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+          );
+        }}
       />
-
-      <ListSection
-        id="education"
-        title="Education"
-        icon={GraduationCap}
-        items={education}
-        renderItem={e => <EducationItem key={e.school} item={e} />}
-      />
-
-      <Section id="skills" title="Skills" icon={Cpu}>
-        <SkillsGrid skills={skills} />
-      </Section>
 
       <Footer links={links} />
     </>


### PR DESCRIPTION
## Summary
- redesign the stacked section component to collapse into tight previews and expand into a grid overlay on hover
- add compact preview renderings for experience, project, and education cards used inside the stacked previews
- update the home page to coordinate section focus, dim inactive stacks, and tune skills cards for the new context

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68cc64c3c760832ab35e61181096904d