### PR TITLE
Refine stacked section previews and full-width expansion

### DIFF
--- a/components/StackedCardPreview.jsx
+++ b/components/StackedCardPreview.jsx
@@ -1,0 +1,56 @@
+function getInitials(value = '') {
+  return value
+    .split(/\s+/)
+    .filter(Boolean)
+    .map(part => part[0]?.toUpperCase())
+    .slice(0, 2)
+    .join('');
+}
+
+export default function StackedCardPreview({
+  title,
+  imageSrc,
+  imageAlt = '',
+  emoji,
+  fallbackInitials,
+  className = '',
+}) {
+  const initials = fallbackInitials ? getInitials(fallbackInitials) : getInitials(title);
+  let mediaContent = null;
+
+  if (imageSrc) {
+    mediaContent = (
+      <img
+        src={imageSrc}
+        alt={imageAlt || `${title} logo`}
+        className="h-full w-full object-contain"
+      />
+    );
+  } else if (emoji) {
+    mediaContent = <span className="text-2xl leading-none">{emoji}</span>;
+  } else if (initials) {
+    mediaContent = (
+      <span className="text-sm font-semibold uppercase tracking-widest text-white/90">
+        {initials}
+      </span>
+    );
+  } else {
+    mediaContent = <span aria-hidden className="text-lg text-white/70">✦</span>;
+  }
+
+  const containerClassName = [
+    'flex h-full items-center gap-4 rounded-3xl border border-white/10 bg-white/5 px-5 py-4 shadow-sm shadow-slate-950/20 backdrop-blur',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div className={containerClassName}>
+      <div className="flex h-12 w-12 items-center justify-center overflow-hidden rounded-2xl border border-white/10 bg-white/10">
+        {mediaContent}
+      </div>
+      <p className="text-base font-semibold leading-snug text-white line-clamp-2">{title}</p>
+    </div>
+  );
+}

--- a/components/StackedCardSection.jsx
+++ b/components/StackedCardSection.jsx
@@ -1,0 +1,350 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import Section from '@/components/ui/Section';
+
+const PREVIEW_CARD_HEIGHT = 128;
+const CASCADE_OFFSET_Y = 28;
+const COLLAPSED_CARD_SHADOW = '0 18px 32px -30px rgba(15, 23, 42, 0.5)';
+const GRID_GAP = 24;
+const MAX_GRID_COLUMNS = 3;
+const TRANSITION_EASING = 'cubic-bezier(0.22, 1, 0.36, 1)';
+
+function getGridColumns(count) {
+  if (count <= 1) {
+    return 1;
+  }
+
+  const ideal = Math.ceil(Math.sqrt(count));
+  return Math.max(2, Math.min(MAX_GRID_COLUMNS, ideal));
+}
+
+export default function StackedCardSection({
+  id,
+  title,
+  icon,
+  items = [],
+  renderItem,
+  keyExtractor,
+  className = '',
+  renderPreview,
+}) {
+  const containerRef = useRef(null);
+  const measurementRef = useRef(null);
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [isCoarsePointer, setIsCoarsePointer] = useState(false);
+  const [expandedLayout, setExpandedLayout] = useState({ positions: [], height: 0 });
+  const [containerHeight, setContainerHeight] = useState(0);
+  const [containerWidth, setContainerWidth] = useState(0);
+
+  const itemCount = items.length;
+  const columns = useMemo(() => {
+    if (itemCount <= 1) {
+      return 1;
+    }
+
+    if (containerWidth > 0) {
+      if (containerWidth < 420) {
+        return 1;
+      }
+
+      if (containerWidth < 640) {
+        return Math.min(itemCount, 2);
+      }
+    }
+
+    return getGridColumns(itemCount);
+  }, [itemCount, containerWidth]);
+
+  const collapsedHeight = useMemo(() => {
+    if (itemCount === 0) {
+      return PREVIEW_CARD_HEIGHT;
+    }
+
+    return PREVIEW_CARD_HEIGHT + CASCADE_OFFSET_Y * Math.max(0, itemCount - 1) + 24;
+  }, [itemCount]);
+
+  const collapsedTransforms = useMemo(() => {
+    return items.map((_, index) => {
+      const translateY = CASCADE_OFFSET_Y * index;
+
+      return `translate3d(0, ${translateY}px, 0)`;
+    });
+  }, [items]);
+
+  useEffect(() => {
+    setContainerHeight(collapsedHeight);
+  }, [collapsedHeight]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return undefined;
+    }
+
+    const mediaQuery = window.matchMedia('(pointer: coarse)');
+    const updatePointerType = event => {
+      setIsCoarsePointer(event.matches);
+    };
+
+    setIsCoarsePointer(mediaQuery.matches);
+    mediaQuery.addEventListener('change', updatePointerType);
+
+    return () => {
+      mediaQuery.removeEventListener('change', updatePointerType);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (isExpanded) {
+      setContainerHeight(expandedLayout.height || collapsedHeight);
+    } else {
+      setContainerHeight(collapsedHeight);
+    }
+  }, [isExpanded, expandedLayout.height, collapsedHeight]);
+
+  const measureLayout = useCallback(() => {
+    const measureEl = measurementRef.current;
+    if (!measureEl) {
+      return;
+    }
+
+    const containerRect = measureEl.getBoundingClientRect();
+    const width = measureEl.offsetWidth;
+    setContainerWidth(previous => (previous === width ? previous : width));
+    const children = Array.from(measureEl.children);
+
+    if (children.length === 0) {
+      setExpandedLayout({ positions: [], height: 0 });
+      return;
+    }
+
+    const positions = children.map(child => {
+      const rect = child.getBoundingClientRect();
+
+      return {
+        x: rect.left - containerRect.left,
+        y: rect.top - containerRect.top,
+        width: rect.width,
+        height: rect.height,
+      };
+    });
+
+    const height = positions.reduce((accumulator, position) => {
+      const bottom = position.y + position.height;
+      return Math.max(accumulator, bottom);
+    }, 0);
+
+    setExpandedLayout({ positions, height });
+  }, []);
+
+  useLayoutEffect(() => {
+    measureLayout();
+  }, [measureLayout, columns, items]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return undefined;
+    }
+
+    const handleResize = () => {
+      measureLayout();
+    };
+
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, [measureLayout]);
+
+  useEffect(() => {
+    if (!isCoarsePointer || !isExpanded) {
+      return undefined;
+    }
+
+    const handleDocumentClick = event => {
+      if (!containerRef.current?.contains(event.target)) {
+        setIsExpanded(false);
+      }
+    };
+
+    document.addEventListener('click', handleDocumentClick);
+
+    return () => {
+      document.removeEventListener('click', handleDocumentClick);
+    };
+  }, [isCoarsePointer, isExpanded]);
+
+  const sectionClassName = [
+    'h-full transition-all duration-500',
+    isExpanded ? 'md:col-span-2' : '',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  const handlePointerEnter = event => {
+    if (isCoarsePointer || event.pointerType === 'touch') {
+      return;
+    }
+
+    setIsExpanded(true);
+  };
+
+  const handlePointerLeave = event => {
+    if (isCoarsePointer || event.pointerType === 'touch') {
+      return;
+    }
+
+    setIsExpanded(false);
+  };
+
+  const handleFocusCapture = () => {
+    setIsExpanded(true);
+  };
+
+  const handleBlurCapture = event => {
+    if (!containerRef.current?.contains(event.relatedTarget)) {
+      setIsExpanded(false);
+    }
+  };
+
+  const handleClickCapture = event => {
+    if (!isCoarsePointer) {
+      return;
+    }
+
+    if (!isExpanded) {
+      setIsExpanded(true);
+      event.preventDefault();
+      event.stopPropagation();
+    }
+  };
+
+  const gridTemplateColumns = `repeat(${columns}, minmax(0, 1fr))`;
+
+  return (
+    <Section id={id} title={title} icon={icon} className={sectionClassName}>
+      <div
+        ref={containerRef}
+        className="relative"
+        data-expanded={isExpanded ? 'true' : 'false'}
+        aria-expanded={isExpanded}
+        onPointerEnter={handlePointerEnter}
+        onPointerLeave={handlePointerLeave}
+        onFocusCapture={handleFocusCapture}
+        onBlurCapture={handleBlurCapture}
+        onClickCapture={handleClickCapture}
+      >
+        <div
+          className="relative transition-[height] duration-[620ms]"
+          style={{ height: containerHeight, transitionTimingFunction: TRANSITION_EASING }}
+        >
+          {itemCount === 0 && (
+            <div className="flex h-full items-center justify-center rounded-3xl border border-white/10 bg-white/5 p-6 text-sm text-white/70">
+              Nothing to display yet.
+            </div>
+          )}
+
+          {items.map((item, index) => {
+            const key = keyExtractor ? keyExtractor(item, index) : index;
+            const collapsedTransform = collapsedTransforms[index] || 'translate3d(0, 0, 0)';
+            const layoutPosition = expandedLayout.positions[index];
+            const expandedTransform = layoutPosition
+              ? `translate3d(${layoutPosition.x}px, ${layoutPosition.y}px, 0)`
+              : 'translate3d(0, 0, 0)';
+            const expandedHeight = layoutPosition?.height ?? PREVIEW_CARD_HEIGHT;
+            const collapsedCardHeight = Math.min(expandedHeight, PREVIEW_CARD_HEIGHT);
+            const isCardExpanded = Boolean(isExpanded);
+            // Collapsed stacks reveal only a preview (title + imagery); full cards fade in on expansion.
+            const previewContent =
+              typeof renderPreview === 'function'
+                ? renderPreview(item, index)
+                : renderItem(item, index, {
+                    isPreview: true,
+                    isExpanded: false,
+                    isActive: false,
+                  });
+
+            return (
+              <div
+                key={key}
+                className="absolute top-0 left-0"
+                style={{
+                  transform: isExpanded ? expandedTransform : collapsedTransform,
+                  width: isExpanded && layoutPosition ? `${layoutPosition.width}px` : '100%',
+                  height: isExpanded ? `${expandedHeight}px` : `${collapsedCardHeight}px`,
+                  zIndex: itemCount - index,
+                  transition: `transform 620ms ${TRANSITION_EASING}, width 620ms ${TRANSITION_EASING}, height 620ms ${TRANSITION_EASING}, box-shadow 420ms ease`,
+                  boxShadow: !isExpanded && index > 0 ? COLLAPSED_CARD_SHADOW : undefined,
+                }}
+              >
+                <div
+                  className="relative h-full overflow-hidden rounded-3xl border border-white/5 bg-white/5 backdrop-blur"
+                >
+                  <div className="absolute inset-0">
+                    <div
+                      className={`absolute inset-0 transition-opacity duration-300 ${
+                        isExpanded ? 'opacity-0 pointer-events-none' : 'opacity-100'
+                      }`}
+                      aria-hidden={isExpanded}
+                    >
+                      {previewContent}
+                    </div>
+                    <div
+                      className={`absolute inset-0 transition-opacity duration-300 ${
+                        isCardExpanded ? 'opacity-100' : 'opacity-0 pointer-events-none'
+                      }`}
+                      aria-hidden={!isCardExpanded}
+                    >
+                      {renderItem(item, index, {
+                        isPreview: false,
+                        isExpanded,
+                        isActive: isExpanded,
+                      })}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        <div
+          ref={measurementRef}
+          aria-hidden="true"
+          className="absolute inset-0 grid opacity-0"
+          style={{
+            pointerEvents: 'none',
+            visibility: 'hidden',
+            gridTemplateColumns,
+            gap: GRID_GAP,
+          }}
+        >
+          {items.map((item, index) => {
+            const key = keyExtractor ? keyExtractor(item, index) : index;
+
+            return (
+              <div key={key} className="h-full">
+                <div className="h-full rounded-3xl border border-white/10 bg-white/5">
+                  {renderItem(item, index, {
+                    isPreview: false,
+                    isExpanded: true,
+                    isActive: true,
+                    isMeasuring: true,
+                  })}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </Section>
+  );
+}
+

--- a/components/ui/Section.jsx
+++ b/components/ui/Section.jsx
@@ -1,18 +1,17 @@
-export default function Section({ id, title, icon, children }) {
-    const Icon = icon;
-    return (
-        <section
-           id={id}
-            className="section-container py-10 scroll-mt-16"
-        >
-	<div className="flex items-center gap-3 mb-6">
-	<div className="p-2 rounded-xl border bg-white dark:bg-slate-900 card">
-	<Icon className="w-5 h-5" />
-	</div>
-	<h2 className="text-2xl font-semibold">{title}</h2>
-	</div>
-	{children}
-	</section>
-    );
+export default function Section({ id, title, icon, children, className = '' }) {
+  const Icon = icon;
+  const sectionClassName = `section-container py-10 scroll-mt-16 ${className}`.trim();
+
+  return (
+    <section id={id} className={sectionClassName}>
+      <div className="flex items-center gap-3 mb-6">
+        <div className="p-2 rounded-xl border bg-white dark:bg-slate-900 card">
+          <Icon className="w-5 h-5" />
+        </div>
+        <h2 className="text-2xl font-semibold">{title}</h2>
+      </div>
+      {children}
+    </section>
+  );
 }
 

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -9,12 +9,13 @@ import Header from '@/components/Header';
 import Hero from '@/components/Hero';
 import AboutSection from '@/components/AboutSection';
 import Footer from '@/components/Footer';
-import ListSection from '@/components/ListSection';
-import Section from '@/components/ui/Section';
+import StackedCardSection from '@/components/StackedCardSection';
+import StackedCardPreview from '@/components/StackedCardPreview';
 import ProjectCard from '@/components/ProjectCard';
 import ExperienceItem from '@/components/ExperienceItem';
 import EducationItem from '@/components/EducationItem';
-import SkillsGrid from '@/components/SkillsGrid';
+import Badge from '@/components/ui/Badge';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/Card';
 import { Trophy, Briefcase, GraduationCap, Cpu, ClipboardList } from 'lucide-react';
 
 const projects = validateProjects(rawProjects) ? rawProjects : [];
@@ -32,6 +33,18 @@ const skills = {
   languages: ['Python', 'Java', 'C', 'JavaScript', 'HTML', 'CSS'],
   tools: ['Git', 'PyTorch', 'NumPy', 'Neovim', 'Matplotlib', 'Jupyter', 'React'],
   platforms: ['Windows', 'macOS', 'Ubuntu Linux'],
+};
+
+const skillCategories = [
+  { title: 'Languages', items: skills.languages },
+  { title: 'Tools & Libraries', items: skills.tools },
+  { title: 'Platforms', items: skills.platforms },
+];
+
+const skillPreviewIcons = {
+  Languages: '💬',
+  'Tools & Libraries': '🧰',
+  Platforms: '🖥️',
 };
 
 const education = [
@@ -76,42 +89,107 @@ export default function Home() {
       <Hero links={links} />
       <AboutSection interests={interests} />
 
-      <ListSection
-        id="experience"
-        title="Experience"
-        icon={Briefcase}
-        items={experience}
-        renderItem={job => <ExperienceItem key={job.org} job={job} />}
-      />
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 space-y-8">
+        <div className="grid gap-8 md:grid-cols-2">
+          <StackedCardSection
+            id="experience"
+            title="Experience"
+            icon={Briefcase}
+            items={experience}
+            keyExtractor={job => job.org}
+            renderItem={job => <ExperienceItem job={job} />}
+            renderPreview={job => (
+              <StackedCardPreview
+                title={job.role}
+                imageSrc={job.img}
+                imageAlt={`${job.org} logo`}
+                fallbackInitials={job.org}
+              />
+            )}
+            className="px-0 md:mx-0"
+          />
+          <StackedCardSection
+            id="projects"
+            title="Projects"
+            icon={Trophy}
+            items={projects}
+            keyExtractor={project => project.title}
+            renderItem={project => <ProjectCard project={project} />}
+            renderPreview={project => (
+              <StackedCardPreview
+                title={project.title}
+                emoji={project.emoji}
+                fallbackInitials={project.title}
+              />
+            )}
+            className="px-0 md:mx-0"
+          />
+        </div>
+        <div className="grid gap-8 md:grid-cols-2">
+          <StackedCardSection
+            id="education"
+            title="Education"
+            icon={GraduationCap}
+            items={education}
+            keyExtractor={item => item.school}
+            renderItem={item => <EducationItem item={item} />}
+            renderPreview={item => (
+              <StackedCardPreview
+                title={item.school}
+                imageSrc={item.img}
+                imageAlt={`${item.school} logo`}
+                fallbackInitials={item.school}
+              />
+            )}
+            className="px-0 md:mx-0"
+          />
+          <StackedCardSection
+            id="other-work"
+            title="Other Work"
+            icon={ClipboardList}
+            items={otherWork}
+            keyExtractor={job => job.org}
+            renderItem={job => <ExperienceItem job={job} />}
+            renderPreview={job => (
+              <StackedCardPreview
+                title={job.role}
+                emoji={job.emoji}
+                fallbackInitials={job.org}
+              />
+            )}
+            className="px-0 md:mx-0"
+          />
+        </div>
+      </div>
 
-      <ListSection
-        id="other-work"
-        title="Other Work"
-        icon={ClipboardList}
-        items={otherWork}
-        renderItem={job => <ExperienceItem key={job.org} job={job} />}
+      <StackedCardSection
+        id="skills"
+        title="Skills"
+        icon={Cpu}
+        items={skillCategories}
+        keyExtractor={category => category.title}
+        renderItem={category => (
+          <Card>
+            <CardHeader>
+              <CardTitle>{category.title}</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="flex flex-wrap gap-2">
+                {category.items.map(item => (
+                  <Badge key={item}>{item}</Badge>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        )}
+        renderPreview={category => (
+          <StackedCardPreview
+            title={category.title}
+            emoji={skillPreviewIcons[category.title]}
+            fallbackInitials={category.title}
+          />
+        )}
       />
-
-      <ListSection
-        id="projects"
-        title="Projects"
-        icon={Trophy}
-        items={projects}
-        columns={2}
-        renderItem={p => <ProjectCard key={p.title} project={p} />}
-      />
-
-      <ListSection
-        id="education"
-        title="Education"
-        icon={GraduationCap}
-        items={education}
-        renderItem={e => <EducationItem key={e.school} item={e} />}
-      />
-
-      <Section id="skills" title="Skills" icon={Cpu}>
-        <SkillsGrid skills={skills} />
-      </Section>
 
       <Footer links={links} />
     </>


### PR DESCRIPTION
## Summary
- align collapsed stacks vertically with subtle offsets and fade in full cards only after expansion
- add a reusable preview card that shows just the title and imagery for each section
- let expanded sections span the full content width so neighboring stacks move aside while cards form responsive grids

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68cc64c3c760832ab35e61181096904d